### PR TITLE
Fix/remove collection owner

### DIFF
--- a/packages/apps/library/src/components/UpdateLibrary/UpdateLibraryFile.tsx
+++ b/packages/apps/library/src/components/UpdateLibrary/UpdateLibraryFile.tsx
@@ -35,7 +35,7 @@ export const UpdateLibraryFile = ({
   const title = metadata.Class?.filter((res) => res.name === 'title')[0].value.Text;
   const read = metadata.Class?.filter((res) => res.name === 'read')[0].value.Text;
   const libraryId = metadata.Class?.filter((res) => res.name === 'library_id')[0].value.Text;
-  const readPermissions = ['public', 'owner', 'collection_owner'];
+  const readPermissions = ['public', 'owner'];
 
   const [selectedFile, setSelectedFile] = useState<File | undefined>(undefined);
   const [inProgress, setInProgress] = useState(false);

--- a/packages/apps/library/src/components/UpdateLibrary/UpdateLibraryWeb.tsx
+++ b/packages/apps/library/src/components/UpdateLibrary/UpdateLibraryWeb.tsx
@@ -25,7 +25,7 @@ export const UpdateLibraryWeb = ({
   const libraryId = metadata.Class?.filter((res) => res.name === 'library_id')[0].value.Text;
   const read = metadata.Class?.filter((res) => res.name === 'read')[0].value.Text;
 
-  const readPermissions = ['public', 'owner', 'collection_owner'];
+  const readPermissions = ['public', 'owner'];
 
   const { enqueueSnackbar } = useSnackbar();
 


### PR DESCRIPTION
Removed collection_owner from select options in the updateLibrary component since it was causing errors. 
Once it's fixed in the canister we'll add it again.  