### PR TITLE
Eng-1140 remove candy field from form section

### DIFF
--- a/packages/candy_editor/src/assets/formTypes/BoolForm/boolForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/BoolForm/boolForm.tsx
@@ -1,13 +1,5 @@
-import React, { useState } from 'react';
-import {
-    Flex,
-    Container,
-    TextInput,
-    CheckboxInput,
-    Button,
-    HR,
-    Select,
-} from '@origyn-sa/origyn-art-ui';
+import React, { useState, useEffect } from 'react';
+import { Flex, TextInput, CheckboxInput, Button, HR, Select } from '@origyn-sa/origyn-art-ui';
 import type { CandyClassEditor, CandyBool } from '../../../types';
 import { VALIDATION_ERRORS } from '../../../constants';
 import { convertToCandyBool } from './converters';
@@ -15,9 +7,11 @@ import { convertToCandyBool } from './converters';
 export const BoolForm = (editor: CandyClassEditor) => {
     const [name, setName] = useState<string>('');
     const [value, setValue] = useState<CandyBool>();
+    const [formValue, setFormValue] = useState<string>('');
     const [immutable, setImmutable] = useState<boolean>(false);
     const [isInvalid, setIsInvalid] = useState<boolean>(false);
     const [validationError, setValidationError] = useState<string>(null);
+    const [isRemoved, setIsRemoved] = useState<boolean>(false);
 
     const onNameChanged = (typedName: React.ChangeEvent<HTMLInputElement>) => {
         setName(typedName.target.value);
@@ -31,63 +25,159 @@ export const BoolForm = (editor: CandyClassEditor) => {
         const boolValue = convertToCandyBool(selectedValue);
         if (boolValue) {
             setValue(boolValue);
+            setFormValue(selectedValue);
             setIsInvalid(false);
         } else {
             setIsInvalid(true);
+            setFormValue(selectedValue);
             setValidationError(VALIDATION_ERRORS.boolean);
         }
     };
 
-    const saveProperty = () => {
-        switch (editor.editorMode) {
-            case "create":
-                editor.addPropertyToCandyClass({
-                    name: name,
-                    value: value,
-                    immutable: immutable,
-                });
-                break;
-            case "edit":
-                alert('edit');
-        }
+    const onRemove = (): void => {
+        setIsRemoved(true);
     };
+
+    const saveProperty = () => {
+        editor.addPropertyToCandyClass({
+            name: name,
+            value: value,
+            immutable: immutable,
+        });
+    };
+
+    useEffect(() => {
+        if (editor.editorMode === 'edit') {
+            const CandyValue = editor.property.value as CandyBool;
+            setName(editor.property.name);
+            setValue(CandyValue);
+            setImmutable(editor.property.immutable);
+            setFormValue(CandyValue.Bool.valueOf().toString());
+        }
+    }, [editor.editorMode]);
+
+    useEffect(() => {
+        if (editor.editorMode === 'edit') {
+            editor.editExistingProperty({
+                name: name,
+                value: value,
+                immutable: immutable,
+            });
+        }
+    }, [name, value, immutable]);
+
+    useEffect(() => {
+        if (editor.editorMode === 'edit') editor.removePropertyFromCandyClass(editor.property);
+    }, [isRemoved]);
 
     return (
         <>
-            <Flex>
-                <TextInput label="Name" onChange={onNameChanged} />
-            </Flex>
-            <Flex>
-                <Select
-                    inputSize="medium"
-                    label="Value"
-                    handleChange={(opt) => {
-                        onValueChanged(opt.value);
-                    }}
-                    options={[
-                        { value: 'true', label: 'true' },
-                        { value: 'false', label: 'false' },
-                    ]}
-                />
-            </Flex>
-            <Flex>
-                <Flex>
-                    <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
-                </Flex>
-            </Flex>
-
             <HR marginTop={8} marginBottom={16} />
-            {isInvalid && (
+            {editor.editorMode === 'create' ? (
                 <>
-                    <Flex>{validationError}</Flex>
+                    <Flex>
+                        <TextInput label="Name" onChange={onNameChanged} />
+                    </Flex>
+                    <Flex>
+                        <Select
+                            inputSize="medium"
+                            label="Value"
+                            handleChange={(opt) => {
+                                onValueChanged(opt.value);
+                            }}
+                            options={[
+                                { value: 'true', label: 'true' },
+                                { value: 'false', label: 'false' },
+                            ]}
+                        />
+                    </Flex>
+                    <Flex>
+                        <Flex>
+                            <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
+                        </Flex>
+                    </Flex>
                     <HR marginTop={8} marginBottom={16} />
+                    {isInvalid && (
+                        <>
+                            <Flex>{validationError}</Flex>
+                            <HR marginTop={8} marginBottom={16} />
+                        </>
+                    )}
+                    <Flex>
+                        <Button size="small" btnType="filled" onClick={saveProperty} disabled={isInvalid}>
+                            Save Property
+                        </Button>
+                    </Flex>
+                </>
+            ) : (
+                <>
+                    {editor.property.immutable ? (
+                        <>
+                            <Flex>
+                                <TextInput label="Name" onChange={onNameChanged} value={name} />
+                            </Flex>
+                            <Flex>
+                                <Select
+                                    inputSize="medium"
+                                    label="Value"
+                                    selectedOption={{
+                                        value: formValue,
+                                        label: formValue,
+                                    }}
+                                />
+                            </Flex>
+                        </>
+                    ) : (
+                        <>
+                            <Flex>
+                                <TextInput label="Name" onChange={onNameChanged} value={name} />
+                            </Flex>
+                            <Flex>
+                                {isInvalid ? (
+                                    <Select
+                                        inputSize="medium"
+                                        label="Value"
+                                        handleChange={(opt) => {
+                                            onValueChanged(opt.value);
+                                        }}
+                                        options={[
+                                            { value: 'true', label: 'true' },
+                                            { value: 'false', label: 'false' },
+                                        ]}
+                                        error={true}
+                                    />
+                                ) : (
+                                    <Select
+                                        inputSize="medium"
+                                        label="Value"
+                                        handleChange={(opt) => {
+                                            onValueChanged(opt.value);
+                                        }}
+                                        options={[
+                                            { value: 'true', label: 'true' },
+                                            { value: 'false', label: 'false' },
+                                        ]}
+                                        selectedOption={{
+                                            value: formValue,
+                                            label: formValue,
+                                        }}
+                                    />
+                                )}
+                            </Flex>
+                            <Flex>
+                                <Flex>
+                                    <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
+                                </Flex>
+                            </Flex>
+                            <Flex>
+                                <Button size="small" btnType="filled" onClick={onRemove}>
+                                    Remove CandyValue
+                                </Button>
+                            </Flex>
+                        </>
+                    )}
                 </>
             )}
-            <Flex>
-                <Button size="small" btnType="filled" onClick={saveProperty} disabled={isInvalid}>
-                    Save Property
-                </Button>
-            </Flex>
         </>
     );
 };

--- a/packages/candy_editor/src/assets/formTypes/BoolForm/boolForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/BoolForm/boolForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Flex, TextInput, CheckboxInput, Button, HR, Select } from '@origyn-sa/origyn-art-ui';
+import { Flex, TextInput, CheckboxInput, Button, Grid, Select, HR } from '@origyn-sa/origyn-art-ui';
 import type { CandyClassEditor, CandyBool } from '../../../types';
 import { VALIDATION_ERRORS } from '../../../constants';
 import { convertToCandyBool } from './converters';
@@ -72,7 +72,6 @@ export const BoolForm = (editor: CandyClassEditor) => {
 
     return (
         <>
-            <HR marginTop={8} marginBottom={16} />
             {editor.editorMode === 'create' ? (
                 <>
                     <Flex>
@@ -113,30 +112,34 @@ export const BoolForm = (editor: CandyClassEditor) => {
                 <>
                     {editor.property.immutable ? (
                         <>
-                            <Flex>
-                                <TextInput label="Name" onChange={onNameChanged} value={name} />
-                            </Flex>
-                            <Flex>
+                            <Grid column={1}>
+                                <TextInput value={name} />
+                            </Grid>
+                            <Grid column={2}>
                                 <Select
                                     inputSize="medium"
-                                    label="Value"
                                     selectedOption={{
                                         value: formValue,
                                         label: formValue,
                                     }}
                                 />
-                            </Flex>
+                            </Grid>
+                            <Grid column={3}>
+                                <span>Property is immutable</span>
+                            </Grid>
+                            <Grid column={4}>
+                                <span>Property is immutable</span>
+                            </Grid>
                         </>
                     ) : (
                         <>
-                            <Flex>
-                                <TextInput label="Name" onChange={onNameChanged} value={name} />
-                            </Flex>
-                            <Flex>
+                            <Grid column={1}>
+                                <TextInput onChange={onNameChanged} value={name} />
+                            </Grid>
+                            <Grid column={2}>
                                 {isInvalid ? (
                                     <Select
                                         inputSize="medium"
-                                        label="Value"
                                         handleChange={(opt) => {
                                             onValueChanged(opt.value);
                                         }}
@@ -149,7 +152,6 @@ export const BoolForm = (editor: CandyClassEditor) => {
                                 ) : (
                                     <Select
                                         inputSize="medium"
-                                        label="Value"
                                         handleChange={(opt) => {
                                             onValueChanged(opt.value);
                                         }}
@@ -163,17 +165,19 @@ export const BoolForm = (editor: CandyClassEditor) => {
                                         }}
                                     />
                                 )}
-                            </Flex>
-                            <Flex>
+                            </Grid>
+                            <Grid column={3}>
+                                <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
+                            </Grid>
+                            <Grid column={4}>
                                 <Flex>
-                                    <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
+                                    <span style={{ marginTop: 'auto', marginBottom: 'auto' }}>
+                                        <Button size="small" btnType="filled" onClick={onRemove}>
+                                            Remove CandyValue
+                                        </Button>
+                                    </span>
                                 </Flex>
-                            </Flex>
-                            <Flex>
-                                <Button size="small" btnType="filled" onClick={onRemove}>
-                                    Remove CandyValue
-                                </Button>
-                            </Flex>
+                            </Grid>
                         </>
                     )}
                 </>

--- a/packages/candy_editor/src/assets/formTypes/BoolForm/boolForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/BoolForm/boolForm.tsx
@@ -5,183 +5,183 @@ import { VALIDATION_ERRORS } from '../../../constants';
 import { convertToCandyBool } from './converters';
 
 export const BoolForm = (editor: CandyClassEditor) => {
-    const [name, setName] = useState<string>('');
-    const [value, setValue] = useState<CandyBool>();
-    const [formValue, setFormValue] = useState<string>('');
-    const [immutable, setImmutable] = useState<boolean>(false);
-    const [isInvalid, setIsInvalid] = useState<boolean>(false);
-    const [validationError, setValidationError] = useState<string>(null);
-    const [isRemoved, setIsRemoved] = useState<boolean>(false);
+  const [name, setName] = useState<string>('');
+  const [value, setValue] = useState<CandyBool>();
+  const [formValue, setFormValue] = useState<string>('');
+  const [immutable, setImmutable] = useState<boolean>(false);
+  const [isInvalid, setIsInvalid] = useState<boolean>(false);
+  const [validationError, setValidationError] = useState<string>(null);
+  const [isRemoved, setIsRemoved] = useState<boolean>(false);
 
-    const onNameChanged = (typedName: React.ChangeEvent<HTMLInputElement>) => {
-        setName(typedName.target.value);
-    };
+  const onNameChanged = (typedName: React.ChangeEvent<HTMLInputElement>) => {
+    setName(typedName.target.value);
+  };
 
-    const onImmutableChanged = () => {
-        setImmutable(!immutable);
-    };
+  const onImmutableChanged = () => {
+    setImmutable(!immutable);
+  };
 
-    const onValueChanged = (selectedValue: string) => {
-        const boolValue = convertToCandyBool(selectedValue);
-        if (boolValue) {
-            setValue(boolValue);
-            setFormValue(selectedValue);
-            setIsInvalid(false);
-        } else {
-            setIsInvalid(true);
-            setFormValue(selectedValue);
-            setValidationError(VALIDATION_ERRORS.boolean);
-        }
-    };
+  const onValueChanged = (selectedValue: string) => {
+    const boolValue = convertToCandyBool(selectedValue);
+    if (boolValue) {
+      setValue(boolValue);
+      setFormValue(selectedValue);
+      setIsInvalid(false);
+    } else {
+      setIsInvalid(true);
+      setFormValue(selectedValue);
+      setValidationError(VALIDATION_ERRORS.boolean);
+    }
+  };
 
-    const onRemove = (): void => {
-        setIsRemoved(true);
-    };
+  const onRemove = (): void => {
+    setIsRemoved(true);
+  };
 
-    const saveProperty = () => {
-        editor.addPropertyToCandyClass({
-            name: name,
-            value: value,
-            immutable: immutable,
-        });
-    };
+  const saveProperty = () => {
+    editor.addPropertyToCandyClass({
+      name: name,
+      value: value,
+      immutable: immutable,
+    });
+  };
 
-    useEffect(() => {
-        if (editor.editorMode === 'edit') {
-            const candyValue = editor.property.value as CandyBool;
-            setName(editor.property.name);
-            setValue(candyValue);
-            setImmutable(editor.property.immutable);
-            setFormValue(candyValue.Bool.valueOf().toString());
-        }
-    }, [editor.editorMode]);
+  useEffect(() => {
+    if (editor.editorMode === 'edit') {
+      const candyValue = editor.property.value as CandyBool;
+      setName(editor.property.name);
+      setValue(candyValue);
+      setImmutable(editor.property.immutable);
+      setFormValue(candyValue.Bool.valueOf().toString());
+    }
+  }, [editor.editorMode]);
 
-    useEffect(() => {
-        if (editor.editorMode === 'edit') {
-            editor.editExistingProperty({
-                name: name,
-                value: value,
-                immutable: immutable,
-            });
-        }
-    }, [name, value, immutable]);
+  useEffect(() => {
+    if (editor.editorMode === 'edit') {
+      editor.editExistingProperty({
+        name: name,
+        value: value,
+        immutable: immutable,
+      });
+    }
+  }, [name, value, immutable]);
 
-    useEffect(() => {
-        if (editor.editorMode === 'edit') editor.removePropertyFromCandyClass(editor.property);
-    }, [isRemoved]);
+  useEffect(() => {
+    if (editor.editorMode === 'edit') editor.removePropertyFromCandyClass(editor.property);
+  }, [isRemoved]);
 
-    return (
+  return (
+    <>
+      {editor.editorMode === 'create' ? (
         <>
-            {editor.editorMode === 'create' ? (
-                <>
-                    <Flex>
-                        <TextInput label="Name" onChange={onNameChanged} />
-                    </Flex>
-                    <Flex>
-                        <Select
-                            inputSize="medium"
-                            label="Value"
-                            handleChange={(opt) => {
-                                onValueChanged(opt.value);
-                            }}
-                            options={[
-                                { value: 'true', label: 'true' },
-                                { value: 'false', label: 'false' },
-                            ]}
-                        />
-                    </Flex>
-                    <Flex>
-                        <Flex>
-                            <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
-                        </Flex>
-                    </Flex>
-                    <HR marginTop={8} marginBottom={16} />
-                    {isInvalid && (
-                        <>
-                            <Flex>{validationError}</Flex>
-                            <HR marginTop={8} marginBottom={16} />
-                        </>
-                    )}
-                    <Flex>
-                        <Button size="small" btnType="filled" onClick={saveProperty} disabled={isInvalid}>
-                            Save Property
-                        </Button>
-                    </Flex>
-                </>
-            ) : (
-                <>
-                    {editor.property.immutable ? (
-                        <>
-                            <Grid column={1}>
-                                <TextInput value={name} />
-                            </Grid>
-                            <Grid column={2}>
-                                <Select
-                                    inputSize="medium"
-                                    selectedOption={{
-                                        value: formValue,
-                                        label: formValue,
-                                    }}
-                                />
-                            </Grid>
-                            <Grid column={3}>
-                                <span>Property is immutable</span>
-                            </Grid>
-                            <Grid column={4}>
-                                <span>Property is immutable</span>
-                            </Grid>
-                        </>
-                    ) : (
-                        <>
-                            <Grid column={1}>
-                                <TextInput onChange={onNameChanged} value={name} />
-                            </Grid>
-                            <Grid column={2}>
-                                {isInvalid ? (
-                                    <Select
-                                        inputSize="medium"
-                                        handleChange={(opt) => {
-                                            onValueChanged(opt.value);
-                                        }}
-                                        options={[
-                                            { value: 'true', label: 'true' },
-                                            { value: 'false', label: 'false' },
-                                        ]}
-                                        error={true}
-                                    />
-                                ) : (
-                                    <Select
-                                        inputSize="medium"
-                                        handleChange={(opt) => {
-                                            onValueChanged(opt.value);
-                                        }}
-                                        options={[
-                                            { value: 'true', label: 'true' },
-                                            { value: 'false', label: 'false' },
-                                        ]}
-                                        selectedOption={{
-                                            value: formValue,
-                                            label: formValue,
-                                        }}
-                                    />
-                                )}
-                            </Grid>
-                            <Grid column={3}>
-                                <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
-                            </Grid>
-                            <Grid column={4}>
-                                <Flex>
-                                    <span style={{ marginTop: 'auto', marginBottom: 'auto' }}>
-                                        <Button size="small" btnType="filled" onClick={onRemove}>
-                                            Remove CandyValue
-                                        </Button>
-                                    </span>
-                                </Flex>
-                            </Grid>
-                        </>
-                    )}
-                </>
-            )}
+          <Flex>
+            <TextInput label="Name" onChange={onNameChanged} />
+          </Flex>
+          <Flex>
+            <Select
+              inputSize="medium"
+              label="Value"
+              handleChange={(opt) => {
+                onValueChanged(opt.value);
+              }}
+              options={[
+                { value: 'true', label: 'true' },
+                { value: 'false', label: 'false' },
+              ]}
+            />
+          </Flex>
+          <Flex>
+            <Flex>
+              <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
+            </Flex>
+          </Flex>
+          <HR marginTop={8} marginBottom={16} />
+          {isInvalid && (
+            <>
+              <Flex>{validationError}</Flex>
+              <HR marginTop={8} marginBottom={16} />
+            </>
+          )}
+          <Flex>
+            <Button size="small" btnType="filled" onClick={saveProperty} disabled={isInvalid}>
+              Save Property
+            </Button>
+          </Flex>
         </>
-    );
+      ) : (
+        <>
+          {editor.property.immutable ? (
+            <>
+              <Grid column={1}>
+                <TextInput value={name} disabled={true} />
+              </Grid>
+              <Grid column={2}>
+                <Select
+                  inputSize="medium"
+                  selectedOption={{
+                    value: formValue,
+                    label: formValue,
+                  }}
+                />
+              </Grid>
+              <Grid column={3}>
+                <span>Property is immutable</span>
+              </Grid>
+              <Grid column={4}>
+                <span>Property is immutable</span>
+              </Grid>
+            </>
+          ) : (
+            <>
+              <Grid column={1}>
+                <TextInput onChange={onNameChanged} value={name} />
+              </Grid>
+              <Grid column={2}>
+                {isInvalid ? (
+                  <Select
+                    inputSize="medium"
+                    handleChange={(opt) => {
+                      onValueChanged(opt.value);
+                    }}
+                    options={[
+                      { value: 'true', label: 'true' },
+                      { value: 'false', label: 'false' },
+                    ]}
+                    error={true}
+                  />
+                ) : (
+                  <Select
+                    inputSize="medium"
+                    handleChange={(opt) => {
+                      onValueChanged(opt.value);
+                    }}
+                    options={[
+                      { value: 'true', label: 'true' },
+                      { value: 'false', label: 'false' },
+                    ]}
+                    selectedOption={{
+                      value: formValue,
+                      label: formValue,
+                    }}
+                  />
+                )}
+              </Grid>
+              <Grid column={3}>
+                <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
+              </Grid>
+              <Grid column={4}>
+                <Flex>
+                  <span style={{ marginTop: 'auto', marginBottom: 'auto' }}>
+                    <Button size="small" btnType="filled" onClick={onRemove}>
+                      Remove CandyValue
+                    </Button>
+                  </span>
+                </Flex>
+              </Grid>
+            </>
+          )}
+        </>
+      )}
+    </>
+  );
 };

--- a/packages/candy_editor/src/assets/formTypes/BoolForm/boolForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/BoolForm/boolForm.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Flex, TextInput, CheckboxInput, Button, Grid, Select, HR } from '@origyn-sa/origyn-art-ui';
 import type { CandyClassEditor, CandyBool } from '../../../types';
-import { VALIDATION_ERRORS } from '../../../constants';
+import { VALIDATION_ERRORS, CREATE_MODE, EDIT_MODE } from '../../../constants';
 import { convertToCandyBool } from './converters';
 
 export const BoolForm = (editor: CandyClassEditor) => {
@@ -42,7 +42,7 @@ export const BoolForm = (editor: CandyClassEditor) => {
   };
 
   useEffect(() => {
-    if (editor.editorMode === 'edit') {
+    if (editor.editorMode === EDIT_MODE) {
       const candyValue = editor.property.value as CandyBool;
       setName(editor.property.name);
       setValue(candyValue);
@@ -52,7 +52,7 @@ export const BoolForm = (editor: CandyClassEditor) => {
   }, [editor.editorMode]);
 
   useEffect(() => {
-    if (editor.editorMode === 'edit') {
+    if (editor.editorMode === EDIT_MODE) {
       editor.editExistingProperty({
         name: name,
         value: value,
@@ -63,7 +63,7 @@ export const BoolForm = (editor: CandyClassEditor) => {
 
   return (
     <>
-      {editor.editorMode === 'create' ? (
+      {editor.editorMode === CREATE_MODE ? (
         <>
           <Flex>
             <TextInput label="Name" onChange={onNameChanged} />

--- a/packages/candy_editor/src/assets/formTypes/BoolForm/boolForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/BoolForm/boolForm.tsx
@@ -39,38 +39,43 @@ export const BoolForm = (editor: CandyClassEditor) => {
     };
 
     const saveProperty = () => {
-        editor.addPropertyToCandyClass({
-            name: name,
-            value: value,
-            immutable: immutable,
-        });
+        switch (editor.editorMode) {
+            case "create":
+                editor.addPropertyToCandyClass({
+                    name: name,
+                    value: value,
+                    immutable: immutable,
+                });
+                break;
+            case "edit":
+                alert('edit');
+        }
     };
 
     return (
-        <Container>
-            <Flex flexFlow="row" gap={16}>
+        <>
+            <Flex>
+                <TextInput label="Name" onChange={onNameChanged} />
+            </Flex>
+            <Flex>
+                <Select
+                    inputSize="medium"
+                    label="Value"
+                    handleChange={(opt) => {
+                        onValueChanged(opt.value);
+                    }}
+                    options={[
+                        { value: 'true', label: 'true' },
+                        { value: 'false', label: 'false' },
+                    ]}
+                />
+            </Flex>
+            <Flex>
                 <Flex>
-                    <TextInput label="Name" onChange={onNameChanged} />
-                </Flex>
-                <Flex>
-                    <Select
-                        inputSize="medium"
-                        label="Value"
-                        handleChange={(opt) => {
-                            onValueChanged(opt.value);
-                        }}
-                        options={[
-                            { value: 'true', label: 'true' },
-                            { value: 'false', label: 'false' },
-                        ]}
-                    />
-                </Flex>
-                <Flex>
-                    <Flex>
-                        <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
-                    </Flex>
+                    <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
                 </Flex>
             </Flex>
+
             <HR marginTop={8} marginBottom={16} />
             {isInvalid && (
                 <>
@@ -83,6 +88,6 @@ export const BoolForm = (editor: CandyClassEditor) => {
                     Save Property
                 </Button>
             </Flex>
-        </Container>
+        </>
     );
 };

--- a/packages/candy_editor/src/assets/formTypes/BoolForm/boolForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/BoolForm/boolForm.tsx
@@ -14,10 +14,19 @@ export const BoolForm = (editor: CandyClassEditor) => {
 
   const onNameChanged = (typedName: React.ChangeEvent<HTMLInputElement>) => {
     setName(typedName.target.value);
+    if (editor.editorMode === EDIT_MODE) {
+      editor.editExistingProperty(
+        { name: typedName.target.value, value, immutable },
+        editor.propertyIndex,
+      );
+    }
   };
 
   const onImmutableChanged = () => {
     setImmutable(!immutable);
+    if (editor.editorMode === EDIT_MODE) {
+      editor.editExistingProperty({ name, value, immutable: !immutable }, editor.propertyIndex);
+    }
   };
 
   const onValueChanged = (selectedValue: string) => {
@@ -26,6 +35,9 @@ export const BoolForm = (editor: CandyClassEditor) => {
       setValue(boolValue);
       setFormValue(selectedValue);
       setIsInvalid(false);
+      if (editor.editorMode === EDIT_MODE) {
+        editor.editExistingProperty({ name, value: boolValue, immutable }, editor.propertyIndex);
+      }
     } else {
       setIsInvalid(true);
       setFormValue(selectedValue);
@@ -38,6 +50,7 @@ export const BoolForm = (editor: CandyClassEditor) => {
       name: name,
       value: value,
       immutable: immutable,
+      id: Math.random().toString(),
     });
   };
 
@@ -50,16 +63,6 @@ export const BoolForm = (editor: CandyClassEditor) => {
       setFormValue(candyValue.Bool.valueOf().toString());
     }
   }, [editor.editorMode]);
-
-  useEffect(() => {
-    if (editor.editorMode === EDIT_MODE) {
-      editor.editExistingProperty({
-        name: name,
-        value: value,
-        immutable: immutable,
-      });
-    }
-  }, [name, value, immutable]);
 
   return (
     <>

--- a/packages/candy_editor/src/assets/formTypes/BoolForm/boolForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/BoolForm/boolForm.tsx
@@ -11,7 +11,6 @@ export const BoolForm = (editor: CandyClassEditor) => {
   const [immutable, setImmutable] = useState<boolean>(false);
   const [isInvalid, setIsInvalid] = useState<boolean>(false);
   const [validationError, setValidationError] = useState<string>(null);
-  const [isRemoved, setIsRemoved] = useState<boolean>(false);
 
   const onNameChanged = (typedName: React.ChangeEvent<HTMLInputElement>) => {
     setName(typedName.target.value);
@@ -32,10 +31,6 @@ export const BoolForm = (editor: CandyClassEditor) => {
       setFormValue(selectedValue);
       setValidationError(VALIDATION_ERRORS.boolean);
     }
-  };
-
-  const onRemove = (): void => {
-    setIsRemoved(true);
   };
 
   const saveProperty = () => {
@@ -65,10 +60,6 @@ export const BoolForm = (editor: CandyClassEditor) => {
       });
     }
   }, [name, value, immutable]);
-
-  useEffect(() => {
-    if (editor.editorMode === 'edit') editor.removePropertyFromCandyClass(editor.property);
-  }, [isRemoved]);
 
   return (
     <>
@@ -168,15 +159,6 @@ export const BoolForm = (editor: CandyClassEditor) => {
               </Grid>
               <Grid column={3}>
                 <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
-              </Grid>
-              <Grid column={4}>
-                <Flex>
-                  <span style={{ marginTop: 'auto', marginBottom: 'auto' }}>
-                    <Button size="small" btnType="filled" onClick={onRemove}>
-                      Remove CandyValue
-                    </Button>
-                  </span>
-                </Flex>
               </Grid>
             </>
           )}

--- a/packages/candy_editor/src/assets/formTypes/BoolForm/boolForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/BoolForm/boolForm.tsx
@@ -48,11 +48,11 @@ export const BoolForm = (editor: CandyClassEditor) => {
 
     useEffect(() => {
         if (editor.editorMode === 'edit') {
-            const CandyValue = editor.property.value as CandyBool;
+            const candyValue = editor.property.value as CandyBool;
             setName(editor.property.name);
-            setValue(CandyValue);
+            setValue(candyValue);
             setImmutable(editor.property.immutable);
-            setFormValue(CandyValue.Bool.valueOf().toString());
+            setFormValue(candyValue.Bool.valueOf().toString());
         }
     }, [editor.editorMode]);
 

--- a/packages/candy_editor/src/assets/formTypes/FloatForm/converters.ts
+++ b/packages/candy_editor/src/assets/formTypes/FloatForm/converters.ts
@@ -1,12 +1,5 @@
 import { CandyFloat } from '../../../types';
-
-export function isInRange(
-    num: number | bigint,
-    min: number | bigint,
-    max: number | bigint,
-): boolean {
-    return num >= min && num <= max;
-}
+import { isInRange } from '../../../utils/functions';
 
 export function convertToCandyFloat(typedValue: string): CandyFloat | undefined {
     if (

--- a/packages/candy_editor/src/assets/formTypes/FloatForm/floatForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/FloatForm/floatForm.tsx
@@ -38,26 +38,30 @@ export const FloatForm = (editor: CandyClassEditor) => {
     };
 
     const saveProperty = () => {
-        editor.addPropertyToCandyClass({
-            name: name,
-            value: value,
-            immutable: immutable,
-        });
+        switch (editor.editorMode) {
+            case "create":
+                editor.addPropertyToCandyClass({
+                    name: name,
+                    value: value,
+                    immutable: immutable,
+                });
+                break;
+            case "edit":
+                alert('edit');
+        }
     };
 
     return (
-        <Container>
-            <Flex flexFlow="row" gap={16}>
+        <>
+            <Flex>
+                <TextInput label="Name" onChange={onNameChanged} />
+            </Flex>
+            <Flex>
+                <TextInput label="Value" onChange={onValueChanged} />
+            </Flex>
+            <Flex>
                 <Flex>
-                    <TextInput label="Name" onChange={onNameChanged} />
-                </Flex>
-                <Flex>
-                    <TextInput label="Value" onChange={onValueChanged} />
-                </Flex>
-                <Flex>
-                    <Flex>
-                        <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
-                    </Flex>
+                    <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
                 </Flex>
             </Flex>
             <HR marginTop={8} marginBottom={16} />
@@ -72,6 +76,6 @@ export const FloatForm = (editor: CandyClassEditor) => {
                     Save Property
                 </Button>
             </Flex>
-        </Container>
+        </>
     );
 };

--- a/packages/candy_editor/src/assets/formTypes/FloatForm/floatForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/FloatForm/floatForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Flex, TextInput, CheckboxInput, Button, HR } from '@origyn-sa/origyn-art-ui';
+import { Flex, TextInput, CheckboxInput, Button, Grid } from '@origyn-sa/origyn-art-ui';
 import type { CandyClassEditor, CandyFloat } from '../../../types';
 import { VALIDATION_ERRORS } from '../../../constants';
 import { convertToCandyFloat } from './converters';
@@ -72,7 +72,6 @@ export const FloatForm = (editor: CandyClassEditor) => {
 
     return (
         <>
-            <HR marginTop={8} marginBottom={16} />
             {editor.editorMode === 'create' ? (
                 <>
                     <Flex>
@@ -100,40 +99,53 @@ export const FloatForm = (editor: CandyClassEditor) => {
                 <>
                     {editor.property.immutable ? (
                         <>
-                            <Flex>
-                                <TextInput label="Name" value={name} disabled={immutable} />
-                            </Flex>
-                            <Flex>
-                                <TextInput label="Value" value={formValue} disabled={immutable} />
-                            </Flex>
+                            <Grid column={1}>
+                                <TextInput
+                                    value={name}
+                                    disabled={immutable}
+                                />
+                            </Grid>
+                            <Grid column={2}>
+                                <TextInput
+                                    value={formValue}
+                                    disabled={immutable}
+                                />
+                            </Grid>
+                            <Grid column={3}>
+                                <span>Property is immutable</span>
+                            </Grid>
+                            <Grid column={4}>
+                                <span>Property is immutable</span>
+                            </Grid>
                         </>
                     ) : (
                         <>
-                            <Flex>
-                                <TextInput label="Name" onChange={onNameChanged} value={name} />
-                            </Flex>
-                            <Flex>
+                            <Grid column={1}>
+                                <TextInput onChange={onNameChanged} value={name} />
+                            </Grid>
+                            <Grid column={2}>
                                 {isInvalid ? (
                                     <TextInput
-                                        label="Value"
                                         onChange={onValueChanged}
                                         error={validationError}
                                         value={formValue}
                                     />
                                 ) : (
-                                    <TextInput label="Value" onChange={onValueChanged} value={formValue} />
+                                    <TextInput onChange={onValueChanged} value={formValue} />
                                 )}
-                            </Flex>
-                            <Flex>
+                            </Grid>
+                            <Grid column={3}>
+                                <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
+                            </Grid>
+                            <Grid column={4}>
                                 <Flex>
-                                    <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
+                                    <span style={{ marginTop: 'auto', marginBottom: 'auto' }}>
+                                        <Button size="small" btnType="filled" onClick={onRemove}>
+                                            Remove CandyValue
+                                        </Button>
+                                    </span>
                                 </Flex>
-                            </Flex>
-                            <Flex>
-                                <Button size="small" btnType="filled" onClick={onRemove}>
-                                    Remove CandyValue
-                                </Button>
-                            </Flex>
+                            </Grid>
                         </>
                     )}
                 </>

--- a/packages/candy_editor/src/assets/formTypes/FloatForm/floatForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/FloatForm/floatForm.tsx
@@ -5,151 +5,141 @@ import { VALIDATION_ERRORS } from '../../../constants';
 import { convertToCandyFloat } from './converters';
 
 export const FloatForm = (editor: CandyClassEditor) => {
-    const [name, setName] = useState<string>('');
-    const [value, setValue] = useState<CandyFloat>();
-    const [formValue, setFormValue] = useState<string>('');
-    const [immutable, setImmutable] = useState<boolean>(false);
-    const [isInvalid, setIsInvalid] = useState<boolean>(false);
-    const [validationError, setValidationError] = useState<string>(null);
-    const [isRemoved, setIsRemoved] = useState<boolean>(false);
+  const [name, setName] = useState<string>('');
+  const [value, setValue] = useState<CandyFloat>();
+  const [formValue, setFormValue] = useState<string>('');
+  const [immutable, setImmutable] = useState<boolean>(false);
+  const [isInvalid, setIsInvalid] = useState<boolean>(false);
+  const [validationError, setValidationError] = useState<string>(null);
+  const [isRemoved, setIsRemoved] = useState<boolean>(false);
 
-    const onNameChanged = (typedName: React.ChangeEvent<HTMLInputElement>) => {
-        setName(typedName.target.value);
-    };
+  const onNameChanged = (typedName: React.ChangeEvent<HTMLInputElement>) => {
+    setName(typedName.target.value);
+  };
 
-    const onImmutableChanged = () => {
-        setImmutable(!immutable);
-    };
+  const onImmutableChanged = () => {
+    setImmutable(!immutable);
+  };
 
-    const onValueChanged = (typedValue: React.ChangeEvent<HTMLInputElement>) => {
-        const floatValue = convertToCandyFloat(typedValue.target.value);
-        if (floatValue) {
-            setValue(floatValue);
-            setFormValue(typedValue.target.value);
-            setIsInvalid(false);
-        } else {
-            setIsInvalid(true);
-            setFormValue(typedValue.target.value);
-            setValidationError(VALIDATION_ERRORS.float);
-        }
-    };
+  const onValueChanged = (typedValue: React.ChangeEvent<HTMLInputElement>) => {
+    const floatValue = convertToCandyFloat(typedValue.target.value);
+    if (floatValue) {
+      setValue(floatValue);
+      setFormValue(typedValue.target.value);
+      setIsInvalid(false);
+    } else {
+      setIsInvalid(true);
+      setFormValue(typedValue.target.value);
+      setValidationError(VALIDATION_ERRORS.float);
+    }
+  };
 
-    const onRemove = (): void => {
-        setIsRemoved(true);
-    };
+  const onRemove = (): void => {
+    setIsRemoved(true);
+  };
 
-    const saveProperty = () => {
-        editor.addPropertyToCandyClass({
-            name: name,
-            value: value,
-            immutable: immutable,
-        });
-    };
+  const saveProperty = () => {
+    editor.addPropertyToCandyClass({
+      name: name,
+      value: value,
+      immutable: immutable,
+    });
+  };
 
-    useEffect(() => {
-        if (editor.editorMode === 'edit') {
-            const candyValue = editor.property.value as CandyFloat;
-            setName(editor.property.name);
-            setValue(candyValue);
-            setImmutable(editor.property.immutable);
-            setFormValue(candyValue.Float.valueOf().toString());
-        }
-    }, [editor.editorMode]);
+  useEffect(() => {
+    if (editor.editorMode === 'edit') {
+      const candyValue = editor.property.value as CandyFloat;
+      setName(editor.property.name);
+      setValue(candyValue);
+      setImmutable(editor.property.immutable);
+      setFormValue(candyValue.Float.valueOf().toString());
+    }
+  }, [editor.editorMode]);
 
-    useEffect(() => {
-        if (editor.editorMode === 'edit') {
-            editor.editExistingProperty({
-                name: name,
-                value: value,
-                immutable: immutable,
-            });
-        }
-    }, [name, value, immutable]);
+  useEffect(() => {
+    if (editor.editorMode === 'edit') {
+      editor.editExistingProperty({
+        name: name,
+        value: value,
+        immutable: immutable,
+      });
+    }
+  }, [name, value, immutable]);
 
-    useEffect(() => {
-        if (editor.editorMode === 'edit') editor.removePropertyFromCandyClass(editor.property);
-    }, [isRemoved]);
+  useEffect(() => {
+    if (editor.editorMode === 'edit') editor.removePropertyFromCandyClass(editor.property);
+  }, [isRemoved]);
 
-    return (
+  return (
+    <>
+      {editor.editorMode === 'create' ? (
         <>
-            {editor.editorMode === 'create' ? (
-                <>
-                    <Flex>
-                        <TextInput label="Name" onChange={onNameChanged} />
-                    </Flex>
-                    <Flex>
-                        {isInvalid ? (
-                            <TextInput label="Value" onChange={onValueChanged} error={validationError} />
-                        ) : (
-                            <TextInput label="Value" onChange={onValueChanged} />
-                        )}
-                    </Flex>
-                    <Flex>
-                        <Flex>
-                            <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
-                        </Flex>
-                    </Flex>
-                    <Flex>
-                        <Button size="small" btnType="filled" onClick={saveProperty} disabled={isInvalid}>
-                            Save Property
-                        </Button>
-                    </Flex>
-                </>
+          <Flex>
+            <TextInput label="Name" onChange={onNameChanged} />
+          </Flex>
+          <Flex>
+            {isInvalid ? (
+              <TextInput label="Value" onChange={onValueChanged} error={validationError} />
             ) : (
-                <>
-                    {editor.property.immutable ? (
-                        <>
-                            <Grid column={1}>
-                                <TextInput
-                                    value={name}
-                                    disabled={immutable}
-                                />
-                            </Grid>
-                            <Grid column={2}>
-                                <TextInput
-                                    value={formValue}
-                                    disabled={immutable}
-                                />
-                            </Grid>
-                            <Grid column={3}>
-                                <span>Property is immutable</span>
-                            </Grid>
-                            <Grid column={4}>
-                                <span>Property is immutable</span>
-                            </Grid>
-                        </>
-                    ) : (
-                        <>
-                            <Grid column={1}>
-                                <TextInput onChange={onNameChanged} value={name} />
-                            </Grid>
-                            <Grid column={2}>
-                                {isInvalid ? (
-                                    <TextInput
-                                        onChange={onValueChanged}
-                                        error={validationError}
-                                        value={formValue}
-                                    />
-                                ) : (
-                                    <TextInput onChange={onValueChanged} value={formValue} />
-                                )}
-                            </Grid>
-                            <Grid column={3}>
-                                <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
-                            </Grid>
-                            <Grid column={4}>
-                                <Flex>
-                                    <span style={{ marginTop: 'auto', marginBottom: 'auto' }}>
-                                        <Button size="small" btnType="filled" onClick={onRemove}>
-                                            Remove CandyValue
-                                        </Button>
-                                    </span>
-                                </Flex>
-                            </Grid>
-                        </>
-                    )}
-                </>
+              <TextInput label="Value" onChange={onValueChanged} />
             )}
+          </Flex>
+          <Flex>
+            <Flex>
+              <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
+            </Flex>
+          </Flex>
+          <Flex>
+            <Button size="small" btnType="filled" onClick={saveProperty} disabled={isInvalid}>
+              Save Property
+            </Button>
+          </Flex>
         </>
-    );
+      ) : (
+        <>
+          {editor.property.immutable ? (
+            <>
+              <Grid column={1}>
+                <TextInput value={name} disabled={true} />
+              </Grid>
+              <Grid column={2}>
+                <TextInput value={formValue} disabled={true} />
+              </Grid>
+              <Grid column={3}>
+                <span>Property is immutable</span>
+              </Grid>
+              <Grid column={4}>
+                <span>Property is immutable</span>
+              </Grid>
+            </>
+          ) : (
+            <>
+              <Grid column={1}>
+                <TextInput onChange={onNameChanged} value={name} />
+              </Grid>
+              <Grid column={2}>
+                {isInvalid ? (
+                  <TextInput onChange={onValueChanged} error={validationError} value={formValue} />
+                ) : (
+                  <TextInput onChange={onValueChanged} value={formValue} />
+                )}
+              </Grid>
+              <Grid column={3}>
+                <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
+              </Grid>
+              <Grid column={4}>
+                <Flex>
+                  <span style={{ marginTop: 'auto', marginBottom: 'auto' }}>
+                    <Button size="small" btnType="filled" onClick={onRemove}>
+                      Remove CandyValue
+                    </Button>
+                  </span>
+                </Flex>
+              </Grid>
+            </>
+          )}
+        </>
+      )}
+    </>
+  );
 };

--- a/packages/candy_editor/src/assets/formTypes/FloatForm/floatForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/FloatForm/floatForm.tsx
@@ -1,12 +1,5 @@
-import React, { useState } from 'react';
-import {
-    Flex,
-    Container,
-    TextInput,
-    CheckboxInput,
-    Button,
-    HR,
-} from '@origyn-sa/origyn-art-ui';
+import React, { useState, useEffect } from 'react';
+import { Flex, TextInput, CheckboxInput, Button, HR } from '@origyn-sa/origyn-art-ui';
 import type { CandyClassEditor, CandyFloat } from '../../../types';
 import { VALIDATION_ERRORS } from '../../../constants';
 import { convertToCandyFloat } from './converters';
@@ -14,9 +7,11 @@ import { convertToCandyFloat } from './converters';
 export const FloatForm = (editor: CandyClassEditor) => {
     const [name, setName] = useState<string>('');
     const [value, setValue] = useState<CandyFloat>();
+    const [formValue, setFormValue] = useState<string>('');
     const [immutable, setImmutable] = useState<boolean>(false);
     const [isInvalid, setIsInvalid] = useState<boolean>(false);
     const [validationError, setValidationError] = useState<string>(null);
+    const [isRemoved, setIsRemoved] = useState<boolean>(false);
 
     const onNameChanged = (typedName: React.ChangeEvent<HTMLInputElement>) => {
         setName(typedName.target.value);
@@ -30,52 +25,119 @@ export const FloatForm = (editor: CandyClassEditor) => {
         const floatValue = convertToCandyFloat(typedValue.target.value);
         if (floatValue) {
             setValue(floatValue);
+            setFormValue(typedValue.target.value);
             setIsInvalid(false);
         } else {
             setIsInvalid(true);
+            setFormValue(typedValue.target.value);
             setValidationError(VALIDATION_ERRORS.float);
         }
     };
 
-    const saveProperty = () => {
-        switch (editor.editorMode) {
-            case "create":
-                editor.addPropertyToCandyClass({
-                    name: name,
-                    value: value,
-                    immutable: immutable,
-                });
-                break;
-            case "edit":
-                alert('edit');
-        }
+    const onRemove = (): void => {
+        setIsRemoved(true);
     };
+
+    const saveProperty = () => {
+        editor.addPropertyToCandyClass({
+            name: name,
+            value: value,
+            immutable: immutable,
+        });
+    };
+
+    useEffect(() => {
+        if (editor.editorMode === 'edit') {
+            const candyValue = editor.property.value as CandyFloat;
+            setName(editor.property.name);
+            setValue(candyValue);
+            setImmutable(editor.property.immutable);
+            setFormValue(candyValue.Float.valueOf().toString());
+        }
+    }, [editor.editorMode]);
+
+    useEffect(() => {
+        if (editor.editorMode === 'edit') {
+            editor.editExistingProperty({
+                name: name,
+                value: value,
+                immutable: immutable,
+            });
+        }
+    }, [name, value, immutable]);
+
+    useEffect(() => {
+        if (editor.editorMode === 'edit') editor.removePropertyFromCandyClass(editor.property);
+    }, [isRemoved]);
 
     return (
         <>
-            <Flex>
-                <TextInput label="Name" onChange={onNameChanged} />
-            </Flex>
-            <Flex>
-                <TextInput label="Value" onChange={onValueChanged} />
-            </Flex>
-            <Flex>
-                <Flex>
-                    <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
-                </Flex>
-            </Flex>
             <HR marginTop={8} marginBottom={16} />
-            {isInvalid && (
+            {editor.editorMode === 'create' ? (
                 <>
-                    <Flex>{validationError}</Flex>
-                    <HR marginTop={8} marginBottom={16} />
+                    <Flex>
+                        <TextInput label="Name" onChange={onNameChanged} />
+                    </Flex>
+                    <Flex>
+                        {isInvalid ? (
+                            <TextInput label="Value" onChange={onValueChanged} error={validationError} />
+                        ) : (
+                            <TextInput label="Value" onChange={onValueChanged} />
+                        )}
+                    </Flex>
+                    <Flex>
+                        <Flex>
+                            <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
+                        </Flex>
+                    </Flex>
+                    <Flex>
+                        <Button size="small" btnType="filled" onClick={saveProperty} disabled={isInvalid}>
+                            Save Property
+                        </Button>
+                    </Flex>
+                </>
+            ) : (
+                <>
+                    {editor.property.immutable ? (
+                        <>
+                            <Flex>
+                                <TextInput label="Name" value={name} disabled={immutable} />
+                            </Flex>
+                            <Flex>
+                                <TextInput label="Value" value={formValue} disabled={immutable} />
+                            </Flex>
+                        </>
+                    ) : (
+                        <>
+                            <Flex>
+                                <TextInput label="Name" onChange={onNameChanged} value={name} />
+                            </Flex>
+                            <Flex>
+                                {isInvalid ? (
+                                    <TextInput
+                                        label="Value"
+                                        onChange={onValueChanged}
+                                        error={validationError}
+                                        value={formValue}
+                                    />
+                                ) : (
+                                    <TextInput label="Value" onChange={onValueChanged} value={formValue} />
+                                )}
+                            </Flex>
+                            <Flex>
+                                <Flex>
+                                    <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
+                                </Flex>
+                            </Flex>
+                            <Flex>
+                                <Button size="small" btnType="filled" onClick={onRemove}>
+                                    Remove CandyValue
+                                </Button>
+                            </Flex>
+                        </>
+                    )}
                 </>
             )}
-            <Flex>
-                <Button size="small" btnType="filled" onClick={saveProperty} disabled={isInvalid}>
-                    Save Property
-                </Button>
-            </Flex>
         </>
     );
 };

--- a/packages/candy_editor/src/assets/formTypes/FloatForm/floatForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/FloatForm/floatForm.tsx
@@ -11,7 +11,6 @@ export const FloatForm = (editor: CandyClassEditor) => {
   const [immutable, setImmutable] = useState<boolean>(false);
   const [isInvalid, setIsInvalid] = useState<boolean>(false);
   const [validationError, setValidationError] = useState<string>(null);
-  const [isRemoved, setIsRemoved] = useState<boolean>(false);
 
   const onNameChanged = (typedName: React.ChangeEvent<HTMLInputElement>) => {
     setName(typedName.target.value);
@@ -32,10 +31,6 @@ export const FloatForm = (editor: CandyClassEditor) => {
       setFormValue(typedValue.target.value);
       setValidationError(VALIDATION_ERRORS.float);
     }
-  };
-
-  const onRemove = (): void => {
-    setIsRemoved(true);
   };
 
   const saveProperty = () => {
@@ -65,10 +60,6 @@ export const FloatForm = (editor: CandyClassEditor) => {
       });
     }
   }, [name, value, immutable]);
-
-  useEffect(() => {
-    if (editor.editorMode === 'edit') editor.removePropertyFromCandyClass(editor.property);
-  }, [isRemoved]);
 
   return (
     <>
@@ -126,15 +117,6 @@ export const FloatForm = (editor: CandyClassEditor) => {
               </Grid>
               <Grid column={3}>
                 <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
-              </Grid>
-              <Grid column={4}>
-                <Flex>
-                  <span style={{ marginTop: 'auto', marginBottom: 'auto' }}>
-                    <Button size="small" btnType="filled" onClick={onRemove}>
-                      Remove CandyValue
-                    </Button>
-                  </span>
-                </Flex>
               </Grid>
             </>
           )}

--- a/packages/candy_editor/src/assets/formTypes/FloatForm/floatForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/FloatForm/floatForm.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Flex, TextInput, CheckboxInput, Button, Grid } from '@origyn-sa/origyn-art-ui';
 import type { CandyClassEditor, CandyFloat } from '../../../types';
-import { VALIDATION_ERRORS } from '../../../constants';
+import { VALIDATION_ERRORS, CREATE_MODE, EDIT_MODE } from '../../../constants';
 import { convertToCandyFloat } from './converters';
 
 export const FloatForm = (editor: CandyClassEditor) => {
@@ -42,7 +42,7 @@ export const FloatForm = (editor: CandyClassEditor) => {
   };
 
   useEffect(() => {
-    if (editor.editorMode === 'edit') {
+    if (editor.editorMode === EDIT_MODE) {
       const candyValue = editor.property.value as CandyFloat;
       setName(editor.property.name);
       setValue(candyValue);
@@ -52,7 +52,7 @@ export const FloatForm = (editor: CandyClassEditor) => {
   }, [editor.editorMode]);
 
   useEffect(() => {
-    if (editor.editorMode === 'edit') {
+    if (editor.editorMode === EDIT_MODE) {
       editor.editExistingProperty({
         name: name,
         value: value,
@@ -63,7 +63,7 @@ export const FloatForm = (editor: CandyClassEditor) => {
 
   return (
     <>
-      {editor.editorMode === 'create' ? (
+      {editor.editorMode === CREATE_MODE ? (
         <>
           <Flex>
             <TextInput label="Name" onChange={onNameChanged} />

--- a/packages/candy_editor/src/assets/formTypes/FloatForm/floatForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/FloatForm/floatForm.tsx
@@ -14,10 +14,19 @@ export const FloatForm = (editor: CandyClassEditor) => {
 
   const onNameChanged = (typedName: React.ChangeEvent<HTMLInputElement>) => {
     setName(typedName.target.value);
+    if (editor.editorMode === EDIT_MODE) {
+      editor.editExistingProperty(
+        { name: typedName.target.value, value, immutable },
+        editor.propertyIndex,
+      );
+    }
   };
 
   const onImmutableChanged = () => {
     setImmutable(!immutable);
+    if (editor.editorMode === EDIT_MODE) {
+      editor.editExistingProperty({ name, value, immutable: !immutable }, editor.propertyIndex);
+    }
   };
 
   const onValueChanged = (typedValue: React.ChangeEvent<HTMLInputElement>) => {
@@ -26,6 +35,9 @@ export const FloatForm = (editor: CandyClassEditor) => {
       setValue(floatValue);
       setFormValue(typedValue.target.value);
       setIsInvalid(false);
+      if (editor.editorMode === EDIT_MODE) {
+        editor.editExistingProperty({ name, value: floatValue, immutable }, editor.propertyIndex);
+      }
     } else {
       setIsInvalid(true);
       setFormValue(typedValue.target.value);
@@ -38,6 +50,7 @@ export const FloatForm = (editor: CandyClassEditor) => {
       name: name,
       value: value,
       immutable: immutable,
+      id: Math.random().toString(),
     });
   };
 
@@ -50,16 +63,6 @@ export const FloatForm = (editor: CandyClassEditor) => {
       setFormValue(candyValue.Float.valueOf().toString());
     }
   }, [editor.editorMode]);
-
-  useEffect(() => {
-    if (editor.editorMode === EDIT_MODE) {
-      editor.editExistingProperty({
-        name: name,
-        value: value,
-        immutable: immutable,
-      });
-    }
-  }, [name, value, immutable]);
 
   return (
     <>

--- a/packages/candy_editor/src/assets/formTypes/IntForms/converters.ts
+++ b/packages/candy_editor/src/assets/formTypes/IntForms/converters.ts
@@ -1,12 +1,5 @@
 import { CandyInt, CandyInt8, CandyInt16, CandyInt32, CandyInt64 } from '../../../types';
-
-export function isInRange(
-  num: number | bigint,
-  min: number | bigint,
-  max: number | bigint,
-): boolean {
-  return num >= min && num <= max;
-}
+import { isInRange } from '../../../utils/functions';
 
 export function convertToCandyInt(typedValue: string): CandyInt | undefined {
   if (/^-?\d+$/.test(typedValue)) {

--- a/packages/candy_editor/src/assets/formTypes/IntForms/converters.ts
+++ b/packages/candy_editor/src/assets/formTypes/IntForms/converters.ts
@@ -1,4 +1,4 @@
-import { CandyInt, CandyInt8, CandyInt16, CandyInt32, CandyInt64 } from '../../../types';
+import { CandyInt, CandyInt8, CandyInt16, CandyInt32, CandyInt64, CandyIntegers, CandyType } from '../../../types';
 import { isInRange } from '../../../utils/functions';
 
 export function convertToCandyInt(typedValue: string): CandyInt | undefined {
@@ -44,3 +44,22 @@ export function convertToCandyInt64(typedValue: string): CandyInt64 | undefined 
   }
   return undefined;
 }
+
+export function convertIntergerNumberToString(
+  naturalNumber: CandyIntegers,
+  typeOfInteger: CandyType,
+): string {
+  switch (typeOfInteger) {
+    case 'Int':
+      return (naturalNumber as CandyInt).Int.valueOf().toString();
+    case 'Int8':
+      return (naturalNumber as CandyInt8).Int8.valueOf().toString();
+    case 'Int16':
+      return (naturalNumber as CandyInt16).Int16.valueOf().toString();
+    case 'Int32':
+      return (naturalNumber as CandyInt32).Int32.valueOf().toString();
+    case 'Int64':
+      return (naturalNumber as CandyInt64).Int64.valueOf().toString();
+  }
+}
+

--- a/packages/candy_editor/src/assets/formTypes/IntForms/converters.ts
+++ b/packages/candy_editor/src/assets/formTypes/IntForms/converters.ts
@@ -45,7 +45,7 @@ export function convertToCandyInt64(typedValue: string): CandyInt64 | undefined 
   return undefined;
 }
 
-export function convertIntergerNumberToString(
+export function convertIntegerNumberToString(
   naturalNumber: CandyIntegers,
   typeOfInteger: CandyType,
 ): string {

--- a/packages/candy_editor/src/assets/formTypes/IntForms/integersForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/IntForms/integersForm.tsx
@@ -18,7 +18,6 @@ export const IntegersForm = (editor: CandyClassEditor) => {
   const [immutable, setImmutable] = useState<boolean>(false);
   const [isInvalid, setIsInvalid] = useState<boolean>(false);
   const [validationError, setValidationError] = useState<string>(null);
-  const [isRemoved, setIsRemoved] = useState<boolean>(false);
 
   const onNameChanged = (typedName: React.ChangeEvent<HTMLInputElement>) => {
     setName(typedName.target.value);
@@ -94,10 +93,6 @@ export const IntegersForm = (editor: CandyClassEditor) => {
     }
   };
 
-  const onRemove = (): void => {
-    setIsRemoved(true);
-  };
-
   const saveProperty = () => {
     editor.addPropertyToCandyClass({
       name: name,
@@ -125,10 +120,6 @@ export const IntegersForm = (editor: CandyClassEditor) => {
       });
     }
   }, [name, value, immutable]);
-
-  useEffect(() => {
-    if (editor.editorMode === 'edit') editor.removePropertyFromCandyClass(editor.property);
-  }, [isRemoved]);
 
   return (
     <>
@@ -186,15 +177,6 @@ export const IntegersForm = (editor: CandyClassEditor) => {
               </Grid>
               <Grid column={3}>
                 <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
-              </Grid>
-              <Grid column={4}>
-                <Flex>
-                  <span style={{ marginTop: 'auto', marginBottom: 'auto' }}>
-                    <Button size="small" btnType="filled" onClick={onRemove}>
-                      Remove CandyValue
-                    </Button>
-                  </span>
-                </Flex>
               </Grid>
             </>
           )}

--- a/packages/candy_editor/src/assets/formTypes/IntForms/integersForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/IntForms/integersForm.tsx
@@ -82,26 +82,30 @@ export const IntegersForm = (editor: CandyClassEditor) => {
     };
 
     const saveProperty = () => {
-        editor.addPropertyToCandyClass({
-            name: name,
-            value: value,
-            immutable: immutable,
-        });
+        switch (editor.editorMode) {
+            case "create":
+                editor.addPropertyToCandyClass({
+                    name: name,
+                    value: value,
+                    immutable: immutable,
+                });
+                break;
+            case "edit":
+                alert('edit');
+        }
     };
 
     return (
-        <Container>
-            <Flex flexFlow="row" gap={16}>
+        <>
+            <Flex>
+                <TextInput label="Name" onChange={onNameChanged} />
+            </Flex>
+            <Flex>
+                <TextInput label="Value" onChange={onValueChanged} />
+            </Flex>
+            <Flex>
                 <Flex>
-                    <TextInput label="Name" onChange={onNameChanged} />
-                </Flex>
-                <Flex>
-                    <TextInput label="Value" onChange={onValueChanged} />
-                </Flex>
-                <Flex>
-                    <Flex>
-                        <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
-                    </Flex>
+                    <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
                 </Flex>
             </Flex>
             <HR marginTop={8} marginBottom={16} />
@@ -116,6 +120,6 @@ export const IntegersForm = (editor: CandyClassEditor) => {
                     Save Property
                 </Button>
             </Flex>
-        </Container>
+        </>
     );
 };

--- a/packages/candy_editor/src/assets/formTypes/IntForms/integersForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/IntForms/integersForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Flex, TextInput, CheckboxInput, Button, HR } from '@origyn-sa/origyn-art-ui';
+import { Flex, TextInput, CheckboxInput, Button, Grid } from '@origyn-sa/origyn-art-ui';
 import type { CandyClassEditor, CandyIntegers } from '../../../types';
 import { VALIDATION_ERRORS } from '../../../constants';
 import {
@@ -134,7 +134,6 @@ export const IntegersForm = (editor: CandyClassEditor) => {
 
     return (
         <>
-            <HR marginTop={8} marginBottom={16} />
             {editor.editorMode === 'create' ? (
                 <>
                     <Flex>
@@ -162,40 +161,53 @@ export const IntegersForm = (editor: CandyClassEditor) => {
                 <>
                     {editor.property.immutable ? (
                         <>
-                            <Flex>
-                                <TextInput label="Name" value={name} disabled={immutable} />
-                            </Flex>
-                            <Flex>
-                                <TextInput label="Value" value={formValue} disabled={immutable} />
-                            </Flex>
+                            <Grid column={1}>
+                                <TextInput
+                                    value={name}
+                                    disabled={immutable}
+                                />
+                            </Grid>
+                            <Grid column={2}>
+                                <TextInput
+                                    value={formValue}
+                                    disabled={immutable}
+                                />
+                            </Grid>
+                            <Grid column={3}>
+                                <span>Property is immutable</span>
+                            </Grid>
+                            <Grid column={4}>
+                                <span>Property is immutable</span>
+                            </Grid>
                         </>
                     ) : (
                         <>
-                            <Flex>
-                                <TextInput label="Name" onChange={onNameChanged} value={name} />
-                            </Flex>
-                            <Flex>
+                            <Grid column={1}>
+                                <TextInput onChange={onNameChanged} value={name} />
+                            </Grid>
+                            <Grid column={2}>
                                 {isInvalid ? (
                                     <TextInput
-                                        label="Value"
                                         onChange={onValueChanged}
                                         error={validationError}
                                         value={formValue}
                                     />
                                 ) : (
-                                    <TextInput label="Value" onChange={onValueChanged} value={formValue} />
+                                    <TextInput onChange={onValueChanged} value={formValue} />
                                 )}
-                            </Flex>
-                            <Flex>
+                            </Grid>
+                            <Grid column={3}>
+                                <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
+                            </Grid>
+                            <Grid column={4}>
                                 <Flex>
-                                    <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
+                                    <span style={{ marginTop: 'auto', marginBottom: 'auto' }}>
+                                        <Button size="small" btnType="filled" onClick={onRemove}>
+                                            Remove CandyValue
+                                        </Button>
+                                    </span>
                                 </Flex>
-                            </Flex>
-                            <Flex>
-                                <Button size="small" btnType="filled" onClick={onRemove}>
-                                    Remove CandyValue
-                                </Button>
-                            </Flex>
+                            </Grid>
                         </>
                     )}
                 </>

--- a/packages/candy_editor/src/assets/formTypes/IntForms/integersForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/IntForms/integersForm.tsx
@@ -3,215 +3,203 @@ import { Flex, TextInput, CheckboxInput, Button, Grid } from '@origyn-sa/origyn-
 import type { CandyClassEditor, CandyIntegers } from '../../../types';
 import { VALIDATION_ERRORS } from '../../../constants';
 import {
-    convertToCandyInt,
-    convertToCandyInt8,
-    convertToCandyInt16,
-    convertToCandyInt32,
-    convertToCandyInt64,
-    convertIntergerNumberToString
+  convertToCandyInt,
+  convertToCandyInt8,
+  convertToCandyInt16,
+  convertToCandyInt32,
+  convertToCandyInt64,
+  convertIntegerNumberToString,
 } from './converters';
 
 export const IntegersForm = (editor: CandyClassEditor) => {
-    const [name, setName] = useState<string>('');
-    const [value, setValue] = useState<CandyIntegers>();
-    const [formValue, setFormValue] = useState<string>('');
-    const [immutable, setImmutable] = useState<boolean>(false);
-    const [isInvalid, setIsInvalid] = useState<boolean>(false);
-    const [validationError, setValidationError] = useState<string>(null);
-    const [isRemoved, setIsRemoved] = useState<boolean>(false);
+  const [name, setName] = useState<string>('');
+  const [value, setValue] = useState<CandyIntegers>();
+  const [formValue, setFormValue] = useState<string>('');
+  const [immutable, setImmutable] = useState<boolean>(false);
+  const [isInvalid, setIsInvalid] = useState<boolean>(false);
+  const [validationError, setValidationError] = useState<string>(null);
+  const [isRemoved, setIsRemoved] = useState<boolean>(false);
 
-    const onNameChanged = (typedName: React.ChangeEvent<HTMLInputElement>) => {
-        setName(typedName.target.value);
-    };
+  const onNameChanged = (typedName: React.ChangeEvent<HTMLInputElement>) => {
+    setName(typedName.target.value);
+  };
 
-    const onImmutableChanged = () => {
-        setImmutable(!immutable);
-    };
+  const onImmutableChanged = () => {
+    setImmutable(!immutable);
+  };
 
-    const onValueChanged = (typedValue: React.ChangeEvent<HTMLInputElement>): void => {
-        let integerValue: CandyIntegers;
-        switch (editor.candyType) {
-            case 'Int':
-                integerValue = convertToCandyInt(typedValue.target.value);
-                if (integerValue) {
-                    setValue(integerValue);
-                    setFormValue(typedValue.target.value);
-                    setIsInvalid(false);
-                } else {
-                    setIsInvalid(true);
-                    setFormValue(typedValue.target.value);
-                    setValidationError(VALIDATION_ERRORS.int);
-                }
-                break;
-            case 'Int8':
-                integerValue = convertToCandyInt8(typedValue.target.value);
-                if (integerValue) {
-                    setValue(integerValue);
-                    setFormValue(typedValue.target.value);
-                    setIsInvalid(false);
-                } else {
-                    setIsInvalid(true);
-                    setFormValue(typedValue.target.value);
-                    setValidationError(VALIDATION_ERRORS.int8);
-                }
-                break;
-            case 'Int16':
-                integerValue = convertToCandyInt16(typedValue.target.value);
-                if (integerValue) {
-                    setValue(integerValue);
-                    setFormValue(typedValue.target.value);
-                    setIsInvalid(false);
-                } else {
-                    setIsInvalid(true);
-                    setFormValue(typedValue.target.value);
-                    setValidationError(VALIDATION_ERRORS.int16);
-                }
-                break;
-            case 'Int32':
-                integerValue = convertToCandyInt32(typedValue.target.value);
-                if (integerValue) {
-                    setValue(integerValue);
-                    setFormValue(typedValue.target.value);
-                    setIsInvalid(false);
-                } else {
-                    setIsInvalid(true);
-                    setFormValue(typedValue.target.value);
-                    setValidationError(VALIDATION_ERRORS.int32);
-                }
-                break;
-            case 'Int64':
-                integerValue = convertToCandyInt64(typedValue.target.value);
-                if (integerValue) {
-                    setValue(integerValue);
-                    setFormValue(typedValue.target.value);
-                    setIsInvalid(false);
-                } else {
-                    setIsInvalid(true);
-                    setFormValue(typedValue.target.value);
-                    setValidationError(VALIDATION_ERRORS.int64);
-                }
-                break;
+  const onValueChanged = (typedValue: React.ChangeEvent<HTMLInputElement>): void => {
+    let integerValue: CandyIntegers;
+    switch (editor.candyType) {
+      case 'Int':
+        integerValue = convertToCandyInt(typedValue.target.value);
+        if (integerValue) {
+          setValue(integerValue);
+          setFormValue(typedValue.target.value);
+          setIsInvalid(false);
+        } else {
+          setIsInvalid(true);
+          setFormValue(typedValue.target.value);
+          setValidationError(VALIDATION_ERRORS.int);
         }
-    };
-
-    const onRemove = (): void => {
-        setIsRemoved(true);
-    };
-
-    const saveProperty = () => {
-        editor.addPropertyToCandyClass({
-            name: name,
-            value: value,
-            immutable: immutable,
-        });
-    };
-
-    useEffect(() => {
-        if (editor.editorMode === 'edit') {
-            const candyValue = editor.property.value as CandyIntegers;
-            setName(editor.property.name);
-            setValue(candyValue);
-            setImmutable(editor.property.immutable);
-            setFormValue(convertIntergerNumberToString(candyValue, editor.candyType));
+        break;
+      case 'Int8':
+        integerValue = convertToCandyInt8(typedValue.target.value);
+        if (integerValue) {
+          setValue(integerValue);
+          setFormValue(typedValue.target.value);
+          setIsInvalid(false);
+        } else {
+          setIsInvalid(true);
+          setFormValue(typedValue.target.value);
+          setValidationError(VALIDATION_ERRORS.int8);
         }
-    }, [editor.editorMode]);
-
-    useEffect(() => {
-        if (editor.editorMode === 'edit') {
-            editor.editExistingProperty({
-                name: name,
-                value: value,
-                immutable: immutable,
-            });
+        break;
+      case 'Int16':
+        integerValue = convertToCandyInt16(typedValue.target.value);
+        if (integerValue) {
+          setValue(integerValue);
+          setFormValue(typedValue.target.value);
+          setIsInvalid(false);
+        } else {
+          setIsInvalid(true);
+          setFormValue(typedValue.target.value);
+          setValidationError(VALIDATION_ERRORS.int16);
         }
-    }, [name, value, immutable]);
+        break;
+      case 'Int32':
+        integerValue = convertToCandyInt32(typedValue.target.value);
+        if (integerValue) {
+          setValue(integerValue);
+          setFormValue(typedValue.target.value);
+          setIsInvalid(false);
+        } else {
+          setIsInvalid(true);
+          setFormValue(typedValue.target.value);
+          setValidationError(VALIDATION_ERRORS.int32);
+        }
+        break;
+      case 'Int64':
+        integerValue = convertToCandyInt64(typedValue.target.value);
+        if (integerValue) {
+          setValue(integerValue);
+          setFormValue(typedValue.target.value);
+          setIsInvalid(false);
+        } else {
+          setIsInvalid(true);
+          setFormValue(typedValue.target.value);
+          setValidationError(VALIDATION_ERRORS.int64);
+        }
+        break;
+    }
+  };
 
-    useEffect(() => {
-        if (editor.editorMode === 'edit') editor.removePropertyFromCandyClass(editor.property);
-    }, [isRemoved]);
+  const onRemove = (): void => {
+    setIsRemoved(true);
+  };
 
+  const saveProperty = () => {
+    editor.addPropertyToCandyClass({
+      name: name,
+      value: value,
+      immutable: immutable,
+    });
+  };
 
+  useEffect(() => {
+    if (editor.editorMode === 'edit') {
+      const candyValue = editor.property.value as CandyIntegers;
+      setName(editor.property.name);
+      setValue(candyValue);
+      setImmutable(editor.property.immutable);
+      setFormValue(convertIntegerNumberToString(candyValue, editor.candyType));
+    }
+  }, [editor.editorMode]);
 
-    return (
+  useEffect(() => {
+    if (editor.editorMode === 'edit') {
+      editor.editExistingProperty({
+        name: name,
+        value: value,
+        immutable: immutable,
+      });
+    }
+  }, [name, value, immutable]);
+
+  useEffect(() => {
+    if (editor.editorMode === 'edit') editor.removePropertyFromCandyClass(editor.property);
+  }, [isRemoved]);
+
+  return (
+    <>
+      {editor.editorMode === 'create' ? (
         <>
-            {editor.editorMode === 'create' ? (
-                <>
-                    <Flex>
-                        <TextInput label="Name" onChange={onNameChanged} />
-                    </Flex>
-                    <Flex>
-                        {isInvalid ? (
-                            <TextInput label="Value" onChange={onValueChanged} error={validationError} />
-                        ) : (
-                            <TextInput label="Value" onChange={onValueChanged} />
-                        )}
-                    </Flex>
-                    <Flex>
-                        <Flex>
-                            <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
-                        </Flex>
-                    </Flex>
-                    <Flex>
-                        <Button size="small" btnType="filled" onClick={saveProperty} disabled={isInvalid}>
-                            Save Property
-                        </Button>
-                    </Flex>
-                </>
+          <Flex>
+            <TextInput label="Name" onChange={onNameChanged} />
+          </Flex>
+          <Flex>
+            {isInvalid ? (
+              <TextInput label="Value" onChange={onValueChanged} error={validationError} />
             ) : (
-                <>
-                    {editor.property.immutable ? (
-                        <>
-                            <Grid column={1}>
-                                <TextInput
-                                    value={name}
-                                    disabled={immutable}
-                                />
-                            </Grid>
-                            <Grid column={2}>
-                                <TextInput
-                                    value={formValue}
-                                    disabled={immutable}
-                                />
-                            </Grid>
-                            <Grid column={3}>
-                                <span>Property is immutable</span>
-                            </Grid>
-                            <Grid column={4}>
-                                <span>Property is immutable</span>
-                            </Grid>
-                        </>
-                    ) : (
-                        <>
-                            <Grid column={1}>
-                                <TextInput onChange={onNameChanged} value={name} />
-                            </Grid>
-                            <Grid column={2}>
-                                {isInvalid ? (
-                                    <TextInput
-                                        onChange={onValueChanged}
-                                        error={validationError}
-                                        value={formValue}
-                                    />
-                                ) : (
-                                    <TextInput onChange={onValueChanged} value={formValue} />
-                                )}
-                            </Grid>
-                            <Grid column={3}>
-                                <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
-                            </Grid>
-                            <Grid column={4}>
-                                <Flex>
-                                    <span style={{ marginTop: 'auto', marginBottom: 'auto' }}>
-                                        <Button size="small" btnType="filled" onClick={onRemove}>
-                                            Remove CandyValue
-                                        </Button>
-                                    </span>
-                                </Flex>
-                            </Grid>
-                        </>
-                    )}
-                </>
+              <TextInput label="Value" onChange={onValueChanged} />
             )}
+          </Flex>
+          <Flex>
+            <Flex>
+              <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
+            </Flex>
+          </Flex>
+          <Flex>
+            <Button size="small" btnType="filled" onClick={saveProperty} disabled={isInvalid}>
+              Save Property
+            </Button>
+          </Flex>
         </>
-    );
+      ) : (
+        <>
+          {editor.property.immutable ? (
+            <>
+              <Grid column={1}>
+                <TextInput value={name} disabled={true} />
+              </Grid>
+              <Grid column={2}>
+                <TextInput value={formValue} disabled={true} />
+              </Grid>
+              <Grid column={3}>
+                <span>Property is immutable</span>
+              </Grid>
+              <Grid column={4}>
+                <span>Property is immutable</span>
+              </Grid>
+            </>
+          ) : (
+            <>
+              <Grid column={1}>
+                <TextInput onChange={onNameChanged} value={name} />
+              </Grid>
+              <Grid column={2}>
+                {isInvalid ? (
+                  <TextInput onChange={onValueChanged} error={validationError} value={formValue} />
+                ) : (
+                  <TextInput onChange={onValueChanged} value={formValue} />
+                )}
+              </Grid>
+              <Grid column={3}>
+                <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
+              </Grid>
+              <Grid column={4}>
+                <Flex>
+                  <span style={{ marginTop: 'auto', marginBottom: 'auto' }}>
+                    <Button size="small" btnType="filled" onClick={onRemove}>
+                      Remove CandyValue
+                    </Button>
+                  </span>
+                </Flex>
+              </Grid>
+            </>
+          )}
+        </>
+      )}
+    </>
+  );
 };

--- a/packages/candy_editor/src/assets/formTypes/IntForms/integersForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/IntForms/integersForm.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Flex, TextInput, CheckboxInput, Button, Grid } from '@origyn-sa/origyn-art-ui';
 import type { CandyClassEditor, CandyIntegers } from '../../../types';
-import { VALIDATION_ERRORS } from '../../../constants';
+import { VALIDATION_ERRORS, EDIT_MODE, CREATE_MODE } from '../../../constants';
 import {
   convertToCandyInt,
   convertToCandyInt8,
@@ -102,7 +102,7 @@ export const IntegersForm = (editor: CandyClassEditor) => {
   };
 
   useEffect(() => {
-    if (editor.editorMode === 'edit') {
+    if (editor.editorMode === EDIT_MODE) {
       const candyValue = editor.property.value as CandyIntegers;
       setName(editor.property.name);
       setValue(candyValue);
@@ -112,7 +112,7 @@ export const IntegersForm = (editor: CandyClassEditor) => {
   }, [editor.editorMode]);
 
   useEffect(() => {
-    if (editor.editorMode === 'edit') {
+    if (editor.editorMode === EDIT_MODE) {
       editor.editExistingProperty({
         name: name,
         value: value,
@@ -123,7 +123,7 @@ export const IntegersForm = (editor: CandyClassEditor) => {
 
   return (
     <>
-      {editor.editorMode === 'create' ? (
+      {editor.editorMode === CREATE_MODE ? (
         <>
           <Flex>
             <TextInput label="Name" onChange={onNameChanged} />

--- a/packages/candy_editor/src/assets/formTypes/IntForms/integersForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/IntForms/integersForm.tsx
@@ -21,10 +21,16 @@ export const IntegersForm = (editor: CandyClassEditor) => {
 
   const onNameChanged = (typedName: React.ChangeEvent<HTMLInputElement>) => {
     setName(typedName.target.value);
+    if (editor.editorMode === EDIT_MODE) {
+      editor.editExistingProperty({ name: typedName.target.value, value, immutable }, editor.propertyIndex);
+    }
   };
 
   const onImmutableChanged = () => {
     setImmutable(!immutable);
+    if (editor.editorMode === EDIT_MODE) {
+      editor.editExistingProperty({ name, value, immutable: !immutable }, editor.propertyIndex);
+    }
   };
 
   const onValueChanged = (typedValue: React.ChangeEvent<HTMLInputElement>): void => {
@@ -36,6 +42,9 @@ export const IntegersForm = (editor: CandyClassEditor) => {
           setValue(integerValue);
           setFormValue(typedValue.target.value);
           setIsInvalid(false);
+          if (editor.editorMode === EDIT_MODE) {
+            editor.editExistingProperty({ name, value: integerValue, immutable }, editor.propertyIndex);
+          }
         } else {
           setIsInvalid(true);
           setFormValue(typedValue.target.value);
@@ -48,6 +57,9 @@ export const IntegersForm = (editor: CandyClassEditor) => {
           setValue(integerValue);
           setFormValue(typedValue.target.value);
           setIsInvalid(false);
+          if (editor.editorMode === EDIT_MODE) {
+            editor.editExistingProperty({ name, value: integerValue, immutable }, editor.propertyIndex);
+          }
         } else {
           setIsInvalid(true);
           setFormValue(typedValue.target.value);
@@ -60,6 +72,9 @@ export const IntegersForm = (editor: CandyClassEditor) => {
           setValue(integerValue);
           setFormValue(typedValue.target.value);
           setIsInvalid(false);
+          if (editor.editorMode === EDIT_MODE) {
+            editor.editExistingProperty({ name, value: integerValue, immutable }, editor.propertyIndex);
+          }
         } else {
           setIsInvalid(true);
           setFormValue(typedValue.target.value);
@@ -72,6 +87,9 @@ export const IntegersForm = (editor: CandyClassEditor) => {
           setValue(integerValue);
           setFormValue(typedValue.target.value);
           setIsInvalid(false);
+          if (editor.editorMode === EDIT_MODE) {
+            editor.editExistingProperty({ name, value: integerValue, immutable }, editor.propertyIndex);
+          }
         } else {
           setIsInvalid(true);
           setFormValue(typedValue.target.value);
@@ -84,6 +102,9 @@ export const IntegersForm = (editor: CandyClassEditor) => {
           setValue(integerValue);
           setFormValue(typedValue.target.value);
           setIsInvalid(false);
+          if (editor.editorMode === EDIT_MODE) {
+            editor.editExistingProperty({ name, value: integerValue, immutable }, editor.propertyIndex);
+          }
         } else {
           setIsInvalid(true);
           setFormValue(typedValue.target.value);
@@ -98,6 +119,7 @@ export const IntegersForm = (editor: CandyClassEditor) => {
       name: name,
       value: value,
       immutable: immutable,
+      id: Math.random().toString(),
     });
   };
 
@@ -110,16 +132,6 @@ export const IntegersForm = (editor: CandyClassEditor) => {
       setFormValue(convertIntegerNumberToString(candyValue, editor.candyType));
     }
   }, [editor.editorMode]);
-
-  useEffect(() => {
-    if (editor.editorMode === EDIT_MODE) {
-      editor.editExistingProperty({
-        name: name,
-        value: value,
-        immutable: immutable,
-      });
-    }
-  }, [name, value, immutable]);
 
   return (
     <>

--- a/packages/candy_editor/src/assets/formTypes/IntForms/integersForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/IntForms/integersForm.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { Flex, Container, TextInput, CheckboxInput, Button, HR } from '@origyn-sa/origyn-art-ui';
+import React, { useState, useEffect } from 'react';
+import { Flex, TextInput, CheckboxInput, Button, HR } from '@origyn-sa/origyn-art-ui';
 import type { CandyClassEditor, CandyIntegers } from '../../../types';
 import { VALIDATION_ERRORS } from '../../../constants';
 import {
@@ -8,14 +8,17 @@ import {
     convertToCandyInt16,
     convertToCandyInt32,
     convertToCandyInt64,
+    convertIntergerNumberToString
 } from './converters';
 
 export const IntegersForm = (editor: CandyClassEditor) => {
     const [name, setName] = useState<string>('');
     const [value, setValue] = useState<CandyIntegers>();
+    const [formValue, setFormValue] = useState<string>('');
     const [immutable, setImmutable] = useState<boolean>(false);
     const [isInvalid, setIsInvalid] = useState<boolean>(false);
     const [validationError, setValidationError] = useState<string>(null);
+    const [isRemoved, setIsRemoved] = useState<boolean>(false);
 
     const onNameChanged = (typedName: React.ChangeEvent<HTMLInputElement>) => {
         setName(typedName.target.value);
@@ -32,9 +35,11 @@ export const IntegersForm = (editor: CandyClassEditor) => {
                 integerValue = convertToCandyInt(typedValue.target.value);
                 if (integerValue) {
                     setValue(integerValue);
+                    setFormValue(typedValue.target.value);
                     setIsInvalid(false);
                 } else {
                     setIsInvalid(true);
+                    setFormValue(typedValue.target.value);
                     setValidationError(VALIDATION_ERRORS.int);
                 }
                 break;
@@ -42,9 +47,11 @@ export const IntegersForm = (editor: CandyClassEditor) => {
                 integerValue = convertToCandyInt8(typedValue.target.value);
                 if (integerValue) {
                     setValue(integerValue);
+                    setFormValue(typedValue.target.value);
                     setIsInvalid(false);
                 } else {
                     setIsInvalid(true);
+                    setFormValue(typedValue.target.value);
                     setValidationError(VALIDATION_ERRORS.int8);
                 }
                 break;
@@ -52,9 +59,11 @@ export const IntegersForm = (editor: CandyClassEditor) => {
                 integerValue = convertToCandyInt16(typedValue.target.value);
                 if (integerValue) {
                     setValue(integerValue);
+                    setFormValue(typedValue.target.value);
                     setIsInvalid(false);
                 } else {
                     setIsInvalid(true);
+                    setFormValue(typedValue.target.value);
                     setValidationError(VALIDATION_ERRORS.int16);
                 }
                 break;
@@ -62,9 +71,11 @@ export const IntegersForm = (editor: CandyClassEditor) => {
                 integerValue = convertToCandyInt32(typedValue.target.value);
                 if (integerValue) {
                     setValue(integerValue);
+                    setFormValue(typedValue.target.value);
                     setIsInvalid(false);
                 } else {
                     setIsInvalid(true);
+                    setFormValue(typedValue.target.value);
                     setValidationError(VALIDATION_ERRORS.int32);
                 }
                 break;
@@ -72,54 +83,123 @@ export const IntegersForm = (editor: CandyClassEditor) => {
                 integerValue = convertToCandyInt64(typedValue.target.value);
                 if (integerValue) {
                     setValue(integerValue);
+                    setFormValue(typedValue.target.value);
                     setIsInvalid(false);
                 } else {
                     setIsInvalid(true);
+                    setFormValue(typedValue.target.value);
                     setValidationError(VALIDATION_ERRORS.int64);
                 }
                 break;
         }
     };
 
-    const saveProperty = () => {
-        switch (editor.editorMode) {
-            case "create":
-                editor.addPropertyToCandyClass({
-                    name: name,
-                    value: value,
-                    immutable: immutable,
-                });
-                break;
-            case "edit":
-                alert('edit');
-        }
+    const onRemove = (): void => {
+        setIsRemoved(true);
     };
+
+    const saveProperty = () => {
+        editor.addPropertyToCandyClass({
+            name: name,
+            value: value,
+            immutable: immutable,
+        });
+    };
+
+    useEffect(() => {
+        if (editor.editorMode === 'edit') {
+            const candyValue = editor.property.value as CandyIntegers;
+            setName(editor.property.name);
+            setValue(candyValue);
+            setImmutable(editor.property.immutable);
+            setFormValue(convertIntergerNumberToString(candyValue, editor.candyType));
+        }
+    }, [editor.editorMode]);
+
+    useEffect(() => {
+        if (editor.editorMode === 'edit') {
+            editor.editExistingProperty({
+                name: name,
+                value: value,
+                immutable: immutable,
+            });
+        }
+    }, [name, value, immutable]);
+
+    useEffect(() => {
+        if (editor.editorMode === 'edit') editor.removePropertyFromCandyClass(editor.property);
+    }, [isRemoved]);
+
+
 
     return (
         <>
-            <Flex>
-                <TextInput label="Name" onChange={onNameChanged} />
-            </Flex>
-            <Flex>
-                <TextInput label="Value" onChange={onValueChanged} />
-            </Flex>
-            <Flex>
-                <Flex>
-                    <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
-                </Flex>
-            </Flex>
             <HR marginTop={8} marginBottom={16} />
-            {isInvalid && (
+            {editor.editorMode === 'create' ? (
                 <>
-                    <Flex>{validationError}</Flex>
-                    <HR marginTop={8} marginBottom={16} />
+                    <Flex>
+                        <TextInput label="Name" onChange={onNameChanged} />
+                    </Flex>
+                    <Flex>
+                        {isInvalid ? (
+                            <TextInput label="Value" onChange={onValueChanged} error={validationError} />
+                        ) : (
+                            <TextInput label="Value" onChange={onValueChanged} />
+                        )}
+                    </Flex>
+                    <Flex>
+                        <Flex>
+                            <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
+                        </Flex>
+                    </Flex>
+                    <Flex>
+                        <Button size="small" btnType="filled" onClick={saveProperty} disabled={isInvalid}>
+                            Save Property
+                        </Button>
+                    </Flex>
+                </>
+            ) : (
+                <>
+                    {editor.property.immutable ? (
+                        <>
+                            <Flex>
+                                <TextInput label="Name" value={name} disabled={immutable} />
+                            </Flex>
+                            <Flex>
+                                <TextInput label="Value" value={formValue} disabled={immutable} />
+                            </Flex>
+                        </>
+                    ) : (
+                        <>
+                            <Flex>
+                                <TextInput label="Name" onChange={onNameChanged} value={name} />
+                            </Flex>
+                            <Flex>
+                                {isInvalid ? (
+                                    <TextInput
+                                        label="Value"
+                                        onChange={onValueChanged}
+                                        error={validationError}
+                                        value={formValue}
+                                    />
+                                ) : (
+                                    <TextInput label="Value" onChange={onValueChanged} value={formValue} />
+                                )}
+                            </Flex>
+                            <Flex>
+                                <Flex>
+                                    <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
+                                </Flex>
+                            </Flex>
+                            <Flex>
+                                <Button size="small" btnType="filled" onClick={onRemove}>
+                                    Remove CandyValue
+                                </Button>
+                            </Flex>
+                        </>
+                    )}
                 </>
             )}
-            <Flex>
-                <Button size="small" btnType="filled" onClick={saveProperty} disabled={isInvalid}>
-                    Save Property
-                </Button>
-            </Flex>
         </>
     );
 };

--- a/packages/candy_editor/src/assets/formTypes/NatForms/converters.ts
+++ b/packages/candy_editor/src/assets/formTypes/NatForms/converters.ts
@@ -1,8 +1,5 @@
 import { CandyNat, CandyNat8, CandyNat16, CandyNat32, CandyNat64 } from '../../../types';
-
-export function isInRange(num: number | bigint, min: number, max: number | bigint): boolean {
-  return num >= min && num <= max;
-}
+import { isInRange } from '../../../utils/functions';
 
 export function convertToCandyNat(typedValue: string): CandyNat | undefined {
   if (/^\d+$/.test(typedValue)) {

--- a/packages/candy_editor/src/assets/formTypes/NatForms/converters.ts
+++ b/packages/candy_editor/src/assets/formTypes/NatForms/converters.ts
@@ -1,4 +1,12 @@
-import { CandyNat, CandyNat8, CandyNat16, CandyNat32, CandyNat64 } from '../../../types';
+import {
+  CandyNat,
+  CandyNat8,
+  CandyNat16,
+  CandyNat32,
+  CandyNat64,
+  CandyNaturals,
+  CandyType,
+} from '../../../types';
 import { isInRange } from '../../../utils/functions';
 
 export function convertToCandyNat(typedValue: string): CandyNat | undefined {
@@ -40,4 +48,22 @@ export function convertToCandyNat64(typedValue: string): CandyNat64 | undefined 
     return { Nat64: bigInt };
   }
   return undefined;
+}
+
+export function convertNaturalNumberToString(
+  naturalNumber: CandyNaturals,
+  typeOfNatural: CandyType,
+): string {
+  switch (typeOfNatural) {
+    case 'Nat':
+      return (naturalNumber as CandyNat).Nat.valueOf().toString();
+    case 'Nat8':
+      return (naturalNumber as CandyNat8).Nat8.valueOf().toString();
+    case 'Nat16':
+      return (naturalNumber as CandyNat16).Nat16.valueOf().toString();
+    case 'Nat32':
+      return (naturalNumber as CandyNat32).Nat32.valueOf().toString();
+    case 'Nat64':
+      return (naturalNumber as CandyNat64).Nat64.valueOf().toString();
+  }
 }

--- a/packages/candy_editor/src/assets/formTypes/NatForms/naturalsForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/NatForms/naturalsForm.tsx
@@ -8,7 +8,7 @@ import {
   convertToCandyNat16,
   convertToCandyNat32,
   convertToCandyNat64,
-  convertNaturalNumberToString
+  convertNaturalNumberToString,
 } from './converters';
 
 export const NaturalsForm = (editor: CandyClassEditor) => {
@@ -113,7 +113,7 @@ export const NaturalsForm = (editor: CandyClassEditor) => {
       setValue(candyValue);
       setImmutable(editor.property.immutable);
       setFormValue(convertNaturalNumberToString(candyValue, editor.candyType));
-      console.log('property', editor.property)
+      console.log('property', editor.property);
     }
   }, [editor.editorMode]);
 
@@ -157,16 +157,10 @@ export const NaturalsForm = (editor: CandyClassEditor) => {
           {editor.property.immutable ? (
             <>
               <Grid column={1}>
-                <TextInput
-                  value={name}
-                  disabled={immutable}
-                />
+                <TextInput value={name} disabled={true} />
               </Grid>
               <Grid column={2}>
-                <TextInput
-                  value={formValue}
-                  disabled={immutable}
-                />
+                <TextInput value={formValue} disabled={true} />
               </Grid>
               <Grid column={3}>
                 <span>Property is immutable</span>
@@ -182,11 +176,7 @@ export const NaturalsForm = (editor: CandyClassEditor) => {
               </Grid>
               <Grid column={2}>
                 {isInvalid ? (
-                  <TextInput
-                    onChange={onValueChanged}
-                    error={validationError}
-                    value={formValue}
-                  />
+                  <TextInput onChange={onValueChanged} error={validationError} value={formValue} />
                 ) : (
                   <TextInput onChange={onValueChanged} value={formValue} />
                 )}

--- a/packages/candy_editor/src/assets/formTypes/NatForms/naturalsForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/NatForms/naturalsForm.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Flex, TextInput, CheckboxInput, Button, Grid } from '@origyn-sa/origyn-art-ui';
-import type { CandyClassEditor, CandyNaturals, Property } from '../../../types';
+import type { CandyClassEditor, CandyNaturals } from '../../../types';
 import { VALIDATION_ERRORS, EDIT_MODE, CREATE_MODE } from '../../../constants';
 import {
   convertToCandyNat,
@@ -21,10 +21,19 @@ export const NaturalsForm = (editor: CandyClassEditor) => {
 
   const onNameChanged = (typedName: React.ChangeEvent<HTMLInputElement>) => {
     setName(typedName.target.value);
+    if (editor.editorMode === EDIT_MODE) {
+      editor.editExistingProperty(
+        { name: typedName.target.value, value, immutable },
+        editor.propertyIndex,
+      );
+    }
   };
 
   const onImmutableChanged = () => {
     setImmutable(!immutable);
+    if (editor.editorMode === EDIT_MODE) {
+      editor.editExistingProperty({ name, value, immutable: !immutable }, editor.propertyIndex);
+    }
   };
 
   const onValueChanged = (typedValue: React.ChangeEvent<HTMLInputElement>): void => {
@@ -36,6 +45,12 @@ export const NaturalsForm = (editor: CandyClassEditor) => {
           setValue(naturalValue);
           setFormValue(typedValue.target.value);
           setIsInvalid(false);
+          if (editor.editorMode === EDIT_MODE) {
+            editor.editExistingProperty(
+              { name, value: naturalValue, immutable },
+              editor.propertyIndex,
+            );
+          }
         } else {
           setIsInvalid(true);
           setFormValue(typedValue.target.value);
@@ -48,6 +63,12 @@ export const NaturalsForm = (editor: CandyClassEditor) => {
           setValue(naturalValue);
           setFormValue(typedValue.target.value);
           setIsInvalid(false);
+          if (editor.editorMode === EDIT_MODE) {
+            editor.editExistingProperty(
+              { name, value: naturalValue, immutable },
+              editor.propertyIndex,
+            );
+          }
         } else {
           setIsInvalid(true);
           setFormValue(typedValue.target.value);
@@ -60,6 +81,12 @@ export const NaturalsForm = (editor: CandyClassEditor) => {
           setValue(naturalValue);
           setFormValue(typedValue.target.value);
           setIsInvalid(false);
+          if (editor.editorMode === EDIT_MODE) {
+            editor.editExistingProperty(
+              { name, value: naturalValue, immutable },
+              editor.propertyIndex,
+            );
+          }
         } else {
           setIsInvalid(true);
           setFormValue(typedValue.target.value);
@@ -72,6 +99,12 @@ export const NaturalsForm = (editor: CandyClassEditor) => {
           setValue(naturalValue);
           setFormValue(typedValue.target.value);
           setIsInvalid(false);
+          if (editor.editorMode === EDIT_MODE) {
+            editor.editExistingProperty(
+              { name, value: naturalValue, immutable },
+              editor.propertyIndex,
+            );
+          }
         } else {
           setIsInvalid(true);
           setFormValue(typedValue.target.value);
@@ -84,6 +117,12 @@ export const NaturalsForm = (editor: CandyClassEditor) => {
           setValue(naturalValue);
           setFormValue(typedValue.target.value);
           setIsInvalid(false);
+          if (editor.editorMode === EDIT_MODE) {
+            editor.editExistingProperty(
+              { name, value: naturalValue, immutable },
+              editor.propertyIndex,
+            );
+          }
         } else {
           setIsInvalid(true);
           setFormValue(typedValue.target.value);
@@ -98,6 +137,7 @@ export const NaturalsForm = (editor: CandyClassEditor) => {
       name: name,
       value: value,
       immutable: immutable,
+      id: Math.random().toString(),
     });
   };
 
@@ -110,16 +150,6 @@ export const NaturalsForm = (editor: CandyClassEditor) => {
       setFormValue(convertNaturalNumberToString(candyValue, editor.candyType));
     }
   }, [editor.editorMode]);
-
-  useEffect(() => {
-    if (editor.editorMode === EDIT_MODE) {
-      editor.editExistingProperty({
-        name: name,
-        value: value,
-        immutable: immutable,
-      });
-    }
-  }, [name, value, immutable]);
 
   return (
     <>

--- a/packages/candy_editor/src/assets/formTypes/NatForms/naturalsForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/NatForms/naturalsForm.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
-import { Flex, Container, TextInput, CheckboxInput, Button, HR } from '@origyn-sa/origyn-art-ui';
-import type { CandyClassEditor, CandyNaturals } from '../../../types';
+import React, { useState, useEffect } from 'react';
+import { Flex, TextInput, CheckboxInput, Button, HR } from '@origyn-sa/origyn-art-ui';
+import type { CandyClassEditor, CandyNat, CandyNat16, CandyNat32, CandyNat64, CandyNat8, CandyNaturals } from '../../../types';
 import { VALIDATION_ERRORS } from '../../../constants';
 import {
   convertToCandyNat,
@@ -8,14 +8,17 @@ import {
   convertToCandyNat16,
   convertToCandyNat32,
   convertToCandyNat64,
+  convertNaturalNumberToString
 } from './converters';
 
 export const NaturalsForm = (editor: CandyClassEditor) => {
   const [name, setName] = useState<string>('');
   const [value, setValue] = useState<CandyNaturals>();
+  const [formValue, setFormValue] = useState<string>('');
   const [immutable, setImmutable] = useState<boolean>(false);
   const [isInvalid, setIsInvalid] = useState<boolean>(false);
   const [validationError, setValidationError] = useState<string>(null);
+  const [isRemoved, setIsRemoved] = useState<boolean>(false);
 
   const onNameChanged = (typedName: React.ChangeEvent<HTMLInputElement>) => {
     setName(typedName.target.value);
@@ -32,9 +35,11 @@ export const NaturalsForm = (editor: CandyClassEditor) => {
         naturalValue = convertToCandyNat(typedValue.target.value);
         if (naturalValue) {
           setValue(naturalValue);
+          setFormValue(typedValue.target.value);
           setIsInvalid(false);
         } else {
           setIsInvalid(true);
+          setFormValue(typedValue.target.value);
           setValidationError(VALIDATION_ERRORS.nat);
         }
         break;
@@ -42,9 +47,11 @@ export const NaturalsForm = (editor: CandyClassEditor) => {
         naturalValue = convertToCandyNat8(typedValue.target.value);
         if (naturalValue) {
           setValue(naturalValue);
+          setFormValue(typedValue.target.value);
           setIsInvalid(false);
         } else {
           setIsInvalid(true);
+          setFormValue(typedValue.target.value);
           setValidationError(VALIDATION_ERRORS.nat8);
         }
         break;
@@ -52,9 +59,11 @@ export const NaturalsForm = (editor: CandyClassEditor) => {
         naturalValue = convertToCandyNat16(typedValue.target.value);
         if (naturalValue) {
           setValue(naturalValue);
+          setFormValue(typedValue.target.value);
           setIsInvalid(false);
         } else {
           setIsInvalid(true);
+          setFormValue(typedValue.target.value);
           setValidationError(VALIDATION_ERRORS.nat16);
         }
         break;
@@ -62,9 +71,11 @@ export const NaturalsForm = (editor: CandyClassEditor) => {
         naturalValue = convertToCandyNat32(typedValue.target.value);
         if (naturalValue) {
           setValue(naturalValue);
+          setFormValue(typedValue.target.value);
           setIsInvalid(false);
         } else {
           setIsInvalid(true);
+          setFormValue(typedValue.target.value);
           setValidationError(VALIDATION_ERRORS.nat32);
         }
         break;
@@ -72,13 +83,19 @@ export const NaturalsForm = (editor: CandyClassEditor) => {
         naturalValue = convertToCandyNat64(typedValue.target.value);
         if (naturalValue) {
           setValue(naturalValue);
+          setFormValue(typedValue.target.value);
           setIsInvalid(false);
         } else {
           setIsInvalid(true);
+          setFormValue(typedValue.target.value);
           setValidationError(VALIDATION_ERRORS.nat64);
         }
         break;
     }
+  };
+
+  const onRemove = (): void => {
+    setIsRemoved(true);
   };
 
   const saveProperty = () => {
@@ -89,32 +106,98 @@ export const NaturalsForm = (editor: CandyClassEditor) => {
     });
   };
 
+  useEffect(() => {
+    if (editor.editorMode === 'edit') {
+      const CandyValue = editor.property.value as CandyNaturals;
+      setName(editor.property.name);
+      setValue(CandyValue);
+      setImmutable(editor.property.immutable);
+      setFormValue(convertNaturalNumberToString(CandyValue, editor.candyType));
+    }
+  }, [editor.editorMode]);
+
+  useEffect(() => {
+    if (editor.editorMode === 'edit') {
+      editor.editExistingProperty({
+        name: name,
+        value: value,
+        immutable: immutable,
+      });
+    }
+  }, [name, value, immutable]);
+
+  useEffect(() => {
+    if (editor.editorMode === 'edit') editor.removePropertyFromCandyClass(editor.property);
+  }, [isRemoved]);
+
   return (
     <>
-      <Flex>
-        <TextInput label="Name" onChange={onNameChanged} />
-      </Flex>
-      <Flex>
-        <TextInput label="Value" onChange={onValueChanged} />
-      </Flex>
-      <Flex>
-        <Flex>
-          <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
-        </Flex>
-      </Flex>
-
       <HR marginTop={8} marginBottom={16} />
-      {isInvalid && (
+      {editor.editorMode === 'create' ? (
         <>
-          <Flex>{validationError}</Flex>
-          <HR marginTop={8} marginBottom={16} />
+          <Flex>
+            <TextInput label="Name" onChange={onNameChanged} />
+          </Flex>
+          <Flex>
+            {isInvalid ? (
+              <TextInput label="Value" onChange={onValueChanged} error={validationError} />
+            ) : (
+              <TextInput label="Value" onChange={onValueChanged} />
+            )}
+          </Flex>
+          <Flex>
+            <Flex>
+              <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
+            </Flex>
+          </Flex>
+          <Flex>
+            <Button size="small" btnType="filled" onClick={saveProperty} disabled={isInvalid}>
+              Save Property
+            </Button>
+          </Flex>
+        </>
+      ) : (
+        <>
+          {editor.property.immutable ? (
+            <>
+              <Flex>
+                <TextInput label="Name" value={name} disabled={immutable} />
+              </Flex>
+              <Flex>
+                <TextInput label="Value" value={formValue} disabled={immutable} />
+              </Flex>
+            </>
+          ) : (
+            <>
+              <Flex>
+                <TextInput label="Name" onChange={onNameChanged} value={name} />
+              </Flex>
+              <Flex>
+                {isInvalid ? (
+                  <TextInput
+                    label="Value"
+                    onChange={onValueChanged}
+                    error={validationError}
+                    value={formValue}
+                  />
+                ) : (
+                  <TextInput label="Value" onChange={onValueChanged} value={formValue} />
+                )}
+              </Flex>
+              <Flex>
+                <Flex>
+                  <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
+                </Flex>
+              </Flex>
+              <Flex>
+                <Button size="small" btnType="filled" onClick={onRemove}>
+                  Remove CandyValue
+                </Button>
+              </Flex>
+            </>
+          )}
         </>
       )}
-      <Flex>
-        <Button size="small" btnType="filled" onClick={saveProperty} disabled={isInvalid}>
-          Save Property
-        </Button>
-      </Flex>
     </>
   );
 };

--- a/packages/candy_editor/src/assets/formTypes/NatForms/naturalsForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/NatForms/naturalsForm.tsx
@@ -15,7 +15,6 @@ export const NaturalsForm = (editor: CandyClassEditor) => {
   const [name, setName] = useState<string>('');
   const [value, setValue] = useState<CandyNaturals>();
   const [formValue, setFormValue] = useState<string>('');
-  const [property, setProperty] = useState<Property>();
   const [immutable, setImmutable] = useState<boolean>(false);
   const [isInvalid, setIsInvalid] = useState<boolean>(false);
   const [validationError, setValidationError] = useState<string>(null);
@@ -94,11 +93,6 @@ export const NaturalsForm = (editor: CandyClassEditor) => {
     }
   };
 
-  const onRemove = (): void => {
-    if (editor.editorMode === 'edit') editor.removePropertyFromCandyClass(property);
-    console.log('pressed');
-  };
-
   const saveProperty = () => {
     editor.addPropertyToCandyClass({
       name: name,
@@ -114,8 +108,6 @@ export const NaturalsForm = (editor: CandyClassEditor) => {
       setValue(candyValue);
       setImmutable(editor.property.immutable);
       setFormValue(convertNaturalNumberToString(candyValue, editor.candyType));
-      setProperty(editor.property);
-      console.log('property', editor.property);
     }
   }, [editor.editorMode]);
 
@@ -185,15 +177,6 @@ export const NaturalsForm = (editor: CandyClassEditor) => {
               </Grid>
               <Grid column={3}>
                 <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
-              </Grid>
-              <Grid column={4}>
-                <Flex>
-                  <span style={{ marginTop: 'auto', marginBottom: 'auto' }}>
-                    <Button size="small" btnType="filled" onClick={() => onRemove()}>
-                      Remove CandyValue
-                    </Button>
-                  </span>
-                </Flex>
               </Grid>
             </>
           )}

--- a/packages/candy_editor/src/assets/formTypes/NatForms/naturalsForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/NatForms/naturalsForm.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Flex, TextInput, CheckboxInput, Button, Grid } from '@origyn-sa/origyn-art-ui';
 import type { CandyClassEditor, CandyNaturals, Property } from '../../../types';
-import { VALIDATION_ERRORS } from '../../../constants';
+import { VALIDATION_ERRORS, EDIT_MODE, CREATE_MODE } from '../../../constants';
 import {
   convertToCandyNat,
   convertToCandyNat8,
@@ -102,7 +102,7 @@ export const NaturalsForm = (editor: CandyClassEditor) => {
   };
 
   useEffect(() => {
-    if (editor.editorMode === 'edit') {
+    if (editor.editorMode === EDIT_MODE) {
       const candyValue = editor.property.value as CandyNaturals;
       setName(editor.property.name);
       setValue(candyValue);
@@ -112,7 +112,7 @@ export const NaturalsForm = (editor: CandyClassEditor) => {
   }, [editor.editorMode]);
 
   useEffect(() => {
-    if (editor.editorMode === 'edit') {
+    if (editor.editorMode === EDIT_MODE) {
       editor.editExistingProperty({
         name: name,
         value: value,
@@ -123,7 +123,7 @@ export const NaturalsForm = (editor: CandyClassEditor) => {
 
   return (
     <>
-      {editor.editorMode === 'create' ? (
+      {editor.editorMode === CREATE_MODE ? (
         <>
           <Flex>
             <TextInput label="Name" onChange={onNameChanged} />

--- a/packages/candy_editor/src/assets/formTypes/NatForms/naturalsForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/NatForms/naturalsForm.tsx
@@ -90,20 +90,19 @@ export const NaturalsForm = (editor: CandyClassEditor) => {
   };
 
   return (
-    <Container>
-      <Flex flexFlow="row" gap={16}>
+    <>
+      <Flex>
+        <TextInput label="Name" onChange={onNameChanged} />
+      </Flex>
+      <Flex>
+        <TextInput label="Value" onChange={onValueChanged} />
+      </Flex>
+      <Flex>
         <Flex>
-          <TextInput label="Name" onChange={onNameChanged} />
-        </Flex>
-        <Flex>
-          <TextInput label="Value" onChange={onValueChanged} />
-        </Flex>
-        <Flex>
-          <Flex>
-            <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
-          </Flex>
+          <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
         </Flex>
       </Flex>
+
       <HR marginTop={8} marginBottom={16} />
       {isInvalid && (
         <>
@@ -116,6 +115,6 @@ export const NaturalsForm = (editor: CandyClassEditor) => {
           Save Property
         </Button>
       </Flex>
-    </Container>
+    </>
   );
 };

--- a/packages/candy_editor/src/assets/formTypes/NatForms/naturalsForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/NatForms/naturalsForm.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import { Flex, TextInput, CheckboxInput, Button, HR } from '@origyn-sa/origyn-art-ui';
-import type { CandyClassEditor, CandyNat, CandyNat16, CandyNat32, CandyNat64, CandyNat8, CandyNaturals } from '../../../types';
+import { Flex, TextInput, CheckboxInput, Button, Grid } from '@origyn-sa/origyn-art-ui';
+import type { CandyClassEditor, CandyNaturals } from '../../../types';
 import { VALIDATION_ERRORS } from '../../../constants';
 import {
   convertToCandyNat,
@@ -95,7 +95,7 @@ export const NaturalsForm = (editor: CandyClassEditor) => {
   };
 
   const onRemove = (): void => {
-    setIsRemoved(true);
+    if (editor.editorMode === 'edit') editor.removePropertyFromCandyClass(editor.property);
   };
 
   const saveProperty = () => {
@@ -113,6 +113,7 @@ export const NaturalsForm = (editor: CandyClassEditor) => {
       setValue(candyValue);
       setImmutable(editor.property.immutable);
       setFormValue(convertNaturalNumberToString(candyValue, editor.candyType));
+      console.log('property', editor.property)
     }
   }, [editor.editorMode]);
 
@@ -126,13 +127,8 @@ export const NaturalsForm = (editor: CandyClassEditor) => {
     }
   }, [name, value, immutable]);
 
-  useEffect(() => {
-    if (editor.editorMode === 'edit') editor.removePropertyFromCandyClass(editor.property);
-  }, [isRemoved]);
-
   return (
     <>
-      <HR marginTop={8} marginBottom={16} />
       {editor.editorMode === 'create' ? (
         <>
           <Flex>
@@ -160,40 +156,53 @@ export const NaturalsForm = (editor: CandyClassEditor) => {
         <>
           {editor.property.immutable ? (
             <>
-              <Flex>
-                <TextInput label="Name" value={name} disabled={immutable} />
-              </Flex>
-              <Flex>
-                <TextInput label="Value" value={formValue} disabled={immutable} />
-              </Flex>
+              <Grid column={1}>
+                <TextInput
+                  value={name}
+                  disabled={immutable}
+                />
+              </Grid>
+              <Grid column={2}>
+                <TextInput
+                  value={formValue}
+                  disabled={immutable}
+                />
+              </Grid>
+              <Grid column={3}>
+                <span>Property is immutable</span>
+              </Grid>
+              <Grid column={4}>
+                <span>Property is immutable</span>
+              </Grid>
             </>
           ) : (
             <>
-              <Flex>
-                <TextInput label="Name" onChange={onNameChanged} value={name} />
-              </Flex>
-              <Flex>
+              <Grid column={1}>
+                <TextInput onChange={onNameChanged} value={name} />
+              </Grid>
+              <Grid column={2}>
                 {isInvalid ? (
                   <TextInput
-                    label="Value"
                     onChange={onValueChanged}
                     error={validationError}
                     value={formValue}
                   />
                 ) : (
-                  <TextInput label="Value" onChange={onValueChanged} value={formValue} />
+                  <TextInput onChange={onValueChanged} value={formValue} />
                 )}
-              </Flex>
-              <Flex>
+              </Grid>
+              <Grid column={3}>
+                <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
+              </Grid>
+              <Grid column={4}>
                 <Flex>
-                  <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
+                  <span style={{ marginTop: 'auto', marginBottom: 'auto' }}>
+                    <Button size="small" btnType="filled" onClick={() => onRemove()}>
+                      Remove CandyValue
+                    </Button>
+                  </span>
                 </Flex>
-              </Flex>
-              <Flex>
-                <Button size="small" btnType="filled" onClick={onRemove}>
-                  Remove CandyValue
-                </Button>
-              </Flex>
+              </Grid>
             </>
           )}
         </>

--- a/packages/candy_editor/src/assets/formTypes/NatForms/naturalsForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/NatForms/naturalsForm.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Flex, TextInput, CheckboxInput, Button, Grid } from '@origyn-sa/origyn-art-ui';
-import type { CandyClassEditor, CandyNaturals } from '../../../types';
+import type { CandyClassEditor, CandyNaturals, Property } from '../../../types';
 import { VALIDATION_ERRORS } from '../../../constants';
 import {
   convertToCandyNat,
@@ -15,10 +15,10 @@ export const NaturalsForm = (editor: CandyClassEditor) => {
   const [name, setName] = useState<string>('');
   const [value, setValue] = useState<CandyNaturals>();
   const [formValue, setFormValue] = useState<string>('');
+  const [property, setProperty] = useState<Property>();
   const [immutable, setImmutable] = useState<boolean>(false);
   const [isInvalid, setIsInvalid] = useState<boolean>(false);
   const [validationError, setValidationError] = useState<string>(null);
-  const [isRemoved, setIsRemoved] = useState<boolean>(false);
 
   const onNameChanged = (typedName: React.ChangeEvent<HTMLInputElement>) => {
     setName(typedName.target.value);
@@ -95,7 +95,8 @@ export const NaturalsForm = (editor: CandyClassEditor) => {
   };
 
   const onRemove = (): void => {
-    if (editor.editorMode === 'edit') editor.removePropertyFromCandyClass(editor.property);
+    if (editor.editorMode === 'edit') editor.removePropertyFromCandyClass(property);
+    console.log('pressed');
   };
 
   const saveProperty = () => {
@@ -113,6 +114,7 @@ export const NaturalsForm = (editor: CandyClassEditor) => {
       setValue(candyValue);
       setImmutable(editor.property.immutable);
       setFormValue(convertNaturalNumberToString(candyValue, editor.candyType));
+      setProperty(editor.property);
       console.log('property', editor.property);
     }
   }, [editor.editorMode]);

--- a/packages/candy_editor/src/assets/formTypes/NatForms/naturalsForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/NatForms/naturalsForm.tsx
@@ -108,11 +108,11 @@ export const NaturalsForm = (editor: CandyClassEditor) => {
 
   useEffect(() => {
     if (editor.editorMode === 'edit') {
-      const CandyValue = editor.property.value as CandyNaturals;
+      const candyValue = editor.property.value as CandyNaturals;
       setName(editor.property.name);
-      setValue(CandyValue);
+      setValue(candyValue);
       setImmutable(editor.property.immutable);
-      setFormValue(convertNaturalNumberToString(CandyValue, editor.candyType));
+      setFormValue(convertNaturalNumberToString(candyValue, editor.candyType));
     }
   }, [editor.editorMode]);
 

--- a/packages/candy_editor/src/assets/formTypes/PrincipalForm/converters.ts
+++ b/packages/candy_editor/src/assets/formTypes/PrincipalForm/converters.ts
@@ -3,7 +3,7 @@ import { Principal } from '@dfinity/principal';
 
 export function convertToCandyPrincipal(typedValue: string): CandyPrincipal | undefined {
     try {
-        const principal = Principal.fromText(typedValue);
+        const principal = Principal.fromText(typedValue.trim());
         return { Principal: principal };
     } catch (e) {
         return undefined;

--- a/packages/candy_editor/src/assets/formTypes/PrincipalForm/principalForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/PrincipalForm/principalForm.tsx
@@ -14,10 +14,19 @@ export const PrincipalForm = (editor: CandyClassEditor) => {
 
   const onNameChanged = (typedName: React.ChangeEvent<HTMLInputElement>) => {
     setName(typedName.target.value);
+    if (editor.editorMode === EDIT_MODE) {
+      editor.editExistingProperty(
+        { name: typedName.target.value, value, immutable },
+        editor.propertyIndex,
+      );
+    }
   };
 
   const onImmutableChanged = () => {
     setImmutable(!immutable);
+    if (editor.editorMode === EDIT_MODE) {
+      editor.editExistingProperty({ name, value, immutable: !immutable }, editor.propertyIndex);
+    }
   };
 
   const onValueChanged = (typedValue: React.ChangeEvent<HTMLInputElement>) => {
@@ -26,6 +35,12 @@ export const PrincipalForm = (editor: CandyClassEditor) => {
       setValue(principalValue);
       setFormValue(typedValue.target.value);
       setIsInvalid(false);
+      if (editor.editorMode === EDIT_MODE) {
+        editor.editExistingProperty(
+          { name, value: principalValue, immutable },
+          editor.propertyIndex,
+        );
+      }
     } else {
       setFormValue(typedValue.target.value);
       setIsInvalid(true);
@@ -38,6 +53,7 @@ export const PrincipalForm = (editor: CandyClassEditor) => {
       name: name,
       value: value,
       immutable: immutable,
+      id: Math.random().toString(),
     });
   };
 
@@ -50,16 +66,6 @@ export const PrincipalForm = (editor: CandyClassEditor) => {
       setFormValue(candyValue.Principal.toString());
     }
   }, [editor.editorMode]);
-
-  useEffect(() => {
-    if (editor.editorMode === EDIT_MODE) {
-      editor.editExistingProperty({
-        name: name,
-        value: value,
-        immutable: immutable,
-      });
-    }
-  }, [name, value, immutable]);
 
   return (
     <>

--- a/packages/candy_editor/src/assets/formTypes/PrincipalForm/principalForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/PrincipalForm/principalForm.tsx
@@ -48,11 +48,11 @@ export const PrincipalForm = (editor: CandyClassEditor) => {
 
     useEffect(() => {
         if (editor.editorMode === 'edit') {
-            const CandyValue = editor.property.value as CandyPrincipal;
+            const candyValue = editor.property.value as CandyPrincipal;
             setName(editor.property.name);
-            setValue(CandyValue);
+            setValue(candyValue);
             setImmutable(editor.property.immutable);
-            setFormValue(CandyValue.Principal.toString());
+            setFormValue(candyValue.Principal.toString());
         }
     }, [editor.editorMode]);
 

--- a/packages/candy_editor/src/assets/formTypes/PrincipalForm/principalForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/PrincipalForm/principalForm.tsx
@@ -1,15 +1,17 @@
-import React, { useState } from 'react';
-import { Flex, Container, TextInput, CheckboxInput, Button, HR } from '@origyn-sa/origyn-art-ui';
+import React, { useState, useEffect } from 'react';
+import { Flex, TextInput, CheckboxInput, Button, HR } from '@origyn-sa/origyn-art-ui';
 import type { CandyClassEditor, CandyPrincipal } from '../../../types';
 import { VALIDATION_ERRORS } from '../../../constants';
 import { convertToCandyPrincipal } from './converters';
 
 export const PrincipalForm = (editor: CandyClassEditor) => {
     const [name, setName] = useState<string>('');
-    const [value, setValue] = useState<CandyPrincipal>();
+    const [value, setValue] = useState<CandyPrincipal>({ Principal: null });
+    const [formValue, setFormValue] = useState<string>('');
     const [immutable, setImmutable] = useState<boolean>(false);
     const [isInvalid, setIsInvalid] = useState<boolean>(false);
     const [validationError, setValidationError] = useState<string>(null);
+    const [isRemoved, setIsRemoved] = useState<boolean>(false);
 
     const onNameChanged = (typedName: React.ChangeEvent<HTMLInputElement>) => {
         setName(typedName.target.value);
@@ -23,53 +25,129 @@ export const PrincipalForm = (editor: CandyClassEditor) => {
         const principalValue = convertToCandyPrincipal(typedValue.target.value);
         if (principalValue) {
             setValue(principalValue);
+            setFormValue(typedValue.target.value);
             setIsInvalid(false);
         } else {
+            setFormValue(typedValue.target.value);
             setIsInvalid(true);
             setValidationError(VALIDATION_ERRORS.principal);
         }
     };
 
-    const saveProperty = () => {
-        switch (editor.editorMode) {
-            case "create":
-                editor.addPropertyToCandyClass({
-                    name: name,
-                    value: value,
-                    immutable: immutable,
-                });
-                break;
-            case "edit":
-                alert('edit');
-        }
+    const onRemove = (): void => {
+        setIsRemoved(true);
     };
+
+    const saveProperty = () => {
+        editor.addPropertyToCandyClass({
+            name: name,
+            value: value,
+            immutable: immutable,
+        });
+    };
+
+    useEffect(() => {
+        if (editor.editorMode === 'edit') {
+            const CandyValue = editor.property.value as CandyPrincipal;
+            setName(editor.property.name);
+            setValue(CandyValue);
+            setImmutable(editor.property.immutable);
+            setFormValue(CandyValue.Principal.toString());
+        }
+    }, [editor.editorMode]);
+
+    useEffect(() => {
+        if (editor.editorMode === 'edit') {
+            editor.editExistingProperty({
+                name: name,
+                value: value,
+                immutable: immutable,
+            });
+        }
+    }, [name, value, immutable]);
+
+    useEffect(() => {
+        if (editor.editorMode === 'edit') editor.removePropertyFromCandyClass(editor.property);
+    }, [isRemoved]);
 
     return (
         <>
-            <Flex>
-                <TextInput label="Name" onChange={onNameChanged} />
-            </Flex>
-            <Flex>
-                <TextInput label="Value" onChange={onValueChanged} />
-            </Flex>
-            <Flex>
-                <Flex>
-                    <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
-                </Flex>
-            </Flex>
-
             <HR marginTop={8} marginBottom={16} />
-            {isInvalid && (
+            {editor.editorMode === 'create' ? (
                 <>
-                    <Flex>{validationError}</Flex>
-                    <HR marginTop={8} marginBottom={16} />
+                    <Flex>
+                        <TextInput label="Name" onChange={onNameChanged} />
+                    </Flex>
+                    <Flex>
+                        {isInvalid ? (
+                            <TextInput label="Value" onChange={onValueChanged} error={validationError} />
+                        ) : (
+                            <TextInput label="Value" onChange={onValueChanged} />
+                        )}
+                    </Flex>
+                    <Flex>
+                        <Flex>
+                            <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
+                        </Flex>
+                    </Flex>
+                    <Flex>
+                        <Button size="small" btnType="filled" onClick={saveProperty} disabled={isInvalid}>
+                            Save Property
+                        </Button>
+                    </Flex>
+                </>
+            ) : (
+                <>
+                    {editor.property.immutable ? (
+                        <>
+                            <Flex>
+                                <TextInput
+                                    label="Name"
+                                    onChange={onNameChanged}
+                                    value={name}
+                                    disabled={immutable}
+                                />
+                            </Flex>
+                            <Flex>
+                                <TextInput
+                                    label="Value"
+                                    onChange={onValueChanged}
+                                    value={formValue}
+                                    disabled={immutable}
+                                />
+                            </Flex>
+                        </>
+                    ) : (
+                        <>
+                            <Flex>
+                                <TextInput label="Name" onChange={onNameChanged} value={name} />
+                            </Flex>
+                            <Flex>
+                                {isInvalid ? (
+                                    <TextInput
+                                        label="Value"
+                                        onChange={onValueChanged}
+                                        error={validationError}
+                                        value={formValue}
+                                    />
+                                ) : (
+                                    <TextInput label="Value" onChange={onValueChanged} value={formValue} />
+                                )}
+                            </Flex>
+                            <Flex>
+                                <Flex>
+                                    <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
+                                </Flex>
+                            </Flex>
+                            <Flex>
+                                <Button size="small" btnType="filled" onClick={onRemove}>
+                                    Remove CandyValue
+                                </Button>
+                            </Flex>
+                        </>
+                    )}
                 </>
             )}
-            <Flex>
-                <Button size="small" btnType="filled" onClick={saveProperty} disabled={isInvalid}>
-                    Save Property
-                </Button>
-            </Flex>
         </>
     );
 };

--- a/packages/candy_editor/src/assets/formTypes/PrincipalForm/principalForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/PrincipalForm/principalForm.tsx
@@ -5,151 +5,141 @@ import { VALIDATION_ERRORS } from '../../../constants';
 import { convertToCandyPrincipal } from './converters';
 
 export const PrincipalForm = (editor: CandyClassEditor) => {
-    const [name, setName] = useState<string>('');
-    const [value, setValue] = useState<CandyPrincipal>({ Principal: null });
-    const [formValue, setFormValue] = useState<string>('');
-    const [immutable, setImmutable] = useState<boolean>(false);
-    const [isInvalid, setIsInvalid] = useState<boolean>(false);
-    const [validationError, setValidationError] = useState<string>(null);
-    const [isRemoved, setIsRemoved] = useState<boolean>(false);
+  const [name, setName] = useState<string>('');
+  const [value, setValue] = useState<CandyPrincipal>({ Principal: null });
+  const [formValue, setFormValue] = useState<string>('');
+  const [immutable, setImmutable] = useState<boolean>(false);
+  const [isInvalid, setIsInvalid] = useState<boolean>(false);
+  const [validationError, setValidationError] = useState<string>(null);
+  const [isRemoved, setIsRemoved] = useState<boolean>(false);
 
-    const onNameChanged = (typedName: React.ChangeEvent<HTMLInputElement>) => {
-        setName(typedName.target.value);
-    };
+  const onNameChanged = (typedName: React.ChangeEvent<HTMLInputElement>) => {
+    setName(typedName.target.value);
+  };
 
-    const onImmutableChanged = () => {
-        setImmutable(!immutable);
-    };
+  const onImmutableChanged = () => {
+    setImmutable(!immutable);
+  };
 
-    const onValueChanged = (typedValue: React.ChangeEvent<HTMLInputElement>) => {
-        const principalValue = convertToCandyPrincipal(typedValue.target.value);
-        if (principalValue) {
-            setValue(principalValue);
-            setFormValue(typedValue.target.value);
-            setIsInvalid(false);
-        } else {
-            setFormValue(typedValue.target.value);
-            setIsInvalid(true);
-            setValidationError(VALIDATION_ERRORS.principal);
-        }
-    };
+  const onValueChanged = (typedValue: React.ChangeEvent<HTMLInputElement>) => {
+    const principalValue = convertToCandyPrincipal(typedValue.target.value);
+    if (principalValue) {
+      setValue(principalValue);
+      setFormValue(typedValue.target.value);
+      setIsInvalid(false);
+    } else {
+      setFormValue(typedValue.target.value);
+      setIsInvalid(true);
+      setValidationError(VALIDATION_ERRORS.principal);
+    }
+  };
 
-    const onRemove = (): void => {
-        setIsRemoved(true);
-    };
+  const onRemove = (): void => {
+    setIsRemoved(true);
+  };
 
-    const saveProperty = () => {
-        editor.addPropertyToCandyClass({
-            name: name,
-            value: value,
-            immutable: immutable,
-        });
-    };
+  const saveProperty = () => {
+    editor.addPropertyToCandyClass({
+      name: name,
+      value: value,
+      immutable: immutable,
+    });
+  };
 
-    useEffect(() => {
-        if (editor.editorMode === 'edit') {
-            const candyValue = editor.property.value as CandyPrincipal;
-            setName(editor.property.name);
-            setValue(candyValue);
-            setImmutable(editor.property.immutable);
-            setFormValue(candyValue.Principal.toString());
-        }
-    }, [editor.editorMode]);
+  useEffect(() => {
+    if (editor.editorMode === 'edit') {
+      const candyValue = editor.property.value as CandyPrincipal;
+      setName(editor.property.name);
+      setValue(candyValue);
+      setImmutable(editor.property.immutable);
+      setFormValue(candyValue.Principal.toString());
+    }
+  }, [editor.editorMode]);
 
-    useEffect(() => {
-        if (editor.editorMode === 'edit') {
-            editor.editExistingProperty({
-                name: name,
-                value: value,
-                immutable: immutable,
-            });
-        }
-    }, [name, value, immutable]);
+  useEffect(() => {
+    if (editor.editorMode === 'edit') {
+      editor.editExistingProperty({
+        name: name,
+        value: value,
+        immutable: immutable,
+      });
+    }
+  }, [name, value, immutable]);
 
-    useEffect(() => {
-        if (editor.editorMode === 'edit') editor.removePropertyFromCandyClass(editor.property);
-    }, [isRemoved]);
+  useEffect(() => {
+    if (editor.editorMode === 'edit') editor.removePropertyFromCandyClass(editor.property);
+  }, [isRemoved]);
 
-    return (
+  return (
+    <>
+      {editor.editorMode === 'create' ? (
         <>
-            {editor.editorMode === 'create' ? (
-                <>
-                    <Flex>
-                        <TextInput label="Name" onChange={onNameChanged} />
-                    </Flex>
-                    <Flex>
-                        {isInvalid ? (
-                            <TextInput label="Value" onChange={onValueChanged} error={validationError} />
-                        ) : (
-                            <TextInput label="Value" onChange={onValueChanged} />
-                        )}
-                    </Flex>
-                    <Flex>
-                        <Flex>
-                            <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
-                        </Flex>
-                    </Flex>
-                    <Flex>
-                        <Button size="small" btnType="filled" onClick={saveProperty} disabled={isInvalid}>
-                            Save Property
-                        </Button>
-                    </Flex>
-                </>
+          <Flex>
+            <TextInput label="Name" onChange={onNameChanged} />
+          </Flex>
+          <Flex>
+            {isInvalid ? (
+              <TextInput label="Value" onChange={onValueChanged} error={validationError} />
             ) : (
-                <>
-                    {editor.property.immutable ? (
-                        <>
-                            <Grid column={1}>
-                                <TextInput
-                                    value={name}
-                                    disabled={immutable}
-                                />
-                            </Grid>
-                            <Grid column={2}>
-                                <TextInput
-                                    value={formValue}
-                                    disabled={immutable}
-                                />
-                            </Grid>
-                            <Grid column={3}>
-                                <span>Property is immutable</span>
-                            </Grid>
-                            <Grid column={4}>
-                                <span>Property is immutable</span>
-                            </Grid>
-                        </>
-                    ) : (
-                        <>
-                            <Grid column={1}>
-                                <TextInput onChange={onNameChanged} value={name} />
-                            </Grid>
-                            <Grid column={2}>
-                                {isInvalid ? (
-                                    <TextInput
-                                        onChange={onValueChanged}
-                                        error={validationError}
-                                        value={formValue}
-                                    />
-                                ) : (
-                                    <TextInput onChange={onValueChanged} value={formValue} />
-                                )}
-                            </Grid>
-                            <Grid column={3}>
-                                <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
-                            </Grid>
-                            <Grid column={4}>
-                                <Flex>
-                                    <span style={{ marginTop: 'auto', marginBottom: 'auto' }}>
-                                        <Button size="small" btnType="filled" onClick={onRemove}>
-                                            Remove CandyValue
-                                        </Button>
-                                    </span>
-                                </Flex>
-                            </Grid>
-                        </>
-                    )}
-                </>
+              <TextInput label="Value" onChange={onValueChanged} />
             )}
+          </Flex>
+          <Flex>
+            <Flex>
+              <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
+            </Flex>
+          </Flex>
+          <Flex>
+            <Button size="small" btnType="filled" onClick={saveProperty} disabled={isInvalid}>
+              Save Property
+            </Button>
+          </Flex>
         </>
-    );
+      ) : (
+        <>
+          {editor.property.immutable ? (
+            <>
+              <Grid column={1}>
+                <TextInput value={name} disabled={true} />
+              </Grid>
+              <Grid column={2}>
+                <TextInput value={formValue} disabled={true} />
+              </Grid>
+              <Grid column={3}>
+                <span>Property is immutable</span>
+              </Grid>
+              <Grid column={4}>
+                <span>Property is immutable</span>
+              </Grid>
+            </>
+          ) : (
+            <>
+              <Grid column={1}>
+                <TextInput onChange={onNameChanged} value={name} />
+              </Grid>
+              <Grid column={2}>
+                {isInvalid ? (
+                  <TextInput onChange={onValueChanged} error={validationError} value={formValue} />
+                ) : (
+                  <TextInput onChange={onValueChanged} value={formValue} />
+                )}
+              </Grid>
+              <Grid column={3}>
+                <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
+              </Grid>
+              <Grid column={4}>
+                <Flex>
+                  <span style={{ marginTop: 'auto', marginBottom: 'auto' }}>
+                    <Button size="small" btnType="filled" onClick={onRemove}>
+                      Remove CandyValue
+                    </Button>
+                  </span>
+                </Flex>
+              </Grid>
+            </>
+          )}
+        </>
+      )}
+    </>
+  );
 };

--- a/packages/candy_editor/src/assets/formTypes/PrincipalForm/principalForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/PrincipalForm/principalForm.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Flex, TextInput, CheckboxInput, Button, HR } from '@origyn-sa/origyn-art-ui';
+import { Flex, TextInput, CheckboxInput, Button, Grid } from '@origyn-sa/origyn-art-ui';
 import type { CandyClassEditor, CandyPrincipal } from '../../../types';
 import { VALIDATION_ERRORS } from '../../../constants';
 import { convertToCandyPrincipal } from './converters';
@@ -72,7 +72,6 @@ export const PrincipalForm = (editor: CandyClassEditor) => {
 
     return (
         <>
-            <HR marginTop={8} marginBottom={16} />
             {editor.editorMode === 'create' ? (
                 <>
                     <Flex>
@@ -100,50 +99,53 @@ export const PrincipalForm = (editor: CandyClassEditor) => {
                 <>
                     {editor.property.immutable ? (
                         <>
-                            <Flex>
+                            <Grid column={1}>
                                 <TextInput
-                                    label="Name"
-                                    onChange={onNameChanged}
                                     value={name}
                                     disabled={immutable}
                                 />
-                            </Flex>
-                            <Flex>
+                            </Grid>
+                            <Grid column={2}>
                                 <TextInput
-                                    label="Value"
-                                    onChange={onValueChanged}
                                     value={formValue}
                                     disabled={immutable}
                                 />
-                            </Flex>
+                            </Grid>
+                            <Grid column={3}>
+                                <span>Property is immutable</span>
+                            </Grid>
+                            <Grid column={4}>
+                                <span>Property is immutable</span>
+                            </Grid>
                         </>
                     ) : (
                         <>
-                            <Flex>
-                                <TextInput label="Name" onChange={onNameChanged} value={name} />
-                            </Flex>
-                            <Flex>
+                            <Grid column={1}>
+                                <TextInput onChange={onNameChanged} value={name} />
+                            </Grid>
+                            <Grid column={2}>
                                 {isInvalid ? (
                                     <TextInput
-                                        label="Value"
                                         onChange={onValueChanged}
                                         error={validationError}
                                         value={formValue}
                                     />
                                 ) : (
-                                    <TextInput label="Value" onChange={onValueChanged} value={formValue} />
+                                    <TextInput onChange={onValueChanged} value={formValue} />
                                 )}
-                            </Flex>
-                            <Flex>
+                            </Grid>
+                            <Grid column={3}>
+                                <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
+                            </Grid>
+                            <Grid column={4}>
                                 <Flex>
-                                    <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
+                                    <span style={{ marginTop: 'auto', marginBottom: 'auto' }}>
+                                        <Button size="small" btnType="filled" onClick={onRemove}>
+                                            Remove CandyValue
+                                        </Button>
+                                    </span>
                                 </Flex>
-                            </Flex>
-                            <Flex>
-                                <Button size="small" btnType="filled" onClick={onRemove}>
-                                    Remove CandyValue
-                                </Button>
-                            </Flex>
+                            </Grid>
                         </>
                     )}
                 </>

--- a/packages/candy_editor/src/assets/formTypes/PrincipalForm/principalForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/PrincipalForm/principalForm.tsx
@@ -31,28 +31,33 @@ export const PrincipalForm = (editor: CandyClassEditor) => {
     };
 
     const saveProperty = () => {
-        editor.addPropertyToCandyClass({
-            name: name,
-            value: value,
-            immutable: immutable,
-        });
+        switch (editor.editorMode) {
+            case "create":
+                editor.addPropertyToCandyClass({
+                    name: name,
+                    value: value,
+                    immutable: immutable,
+                });
+                break;
+            case "edit":
+                alert('edit');
+        }
     };
 
     return (
-        <Container>
-            <Flex flexFlow="row" gap={16}>
+        <>
+            <Flex>
+                <TextInput label="Name" onChange={onNameChanged} />
+            </Flex>
+            <Flex>
+                <TextInput label="Value" onChange={onValueChanged} />
+            </Flex>
+            <Flex>
                 <Flex>
-                    <TextInput label="Name" onChange={onNameChanged} />
-                </Flex>
-                <Flex>
-                    <TextInput label="Value" onChange={onValueChanged} />
-                </Flex>
-                <Flex>
-                    <Flex>
-                        <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
-                    </Flex>
+                    <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
                 </Flex>
             </Flex>
+
             <HR marginTop={8} marginBottom={16} />
             {isInvalid && (
                 <>
@@ -65,6 +70,6 @@ export const PrincipalForm = (editor: CandyClassEditor) => {
                     Save Property
                 </Button>
             </Flex>
-        </Container>
+        </>
     );
 };

--- a/packages/candy_editor/src/assets/formTypes/PrincipalForm/principalForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/PrincipalForm/principalForm.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Flex, TextInput, CheckboxInput, Button, Grid } from '@origyn-sa/origyn-art-ui';
 import type { CandyClassEditor, CandyPrincipal } from '../../../types';
-import { VALIDATION_ERRORS } from '../../../constants';
+import { VALIDATION_ERRORS, CREATE_MODE, EDIT_MODE } from '../../../constants';
 import { convertToCandyPrincipal } from './converters';
 
 export const PrincipalForm = (editor: CandyClassEditor) => {
@@ -42,7 +42,7 @@ export const PrincipalForm = (editor: CandyClassEditor) => {
   };
 
   useEffect(() => {
-    if (editor.editorMode === 'edit') {
+    if (editor.editorMode === EDIT_MODE) {
       const candyValue = editor.property.value as CandyPrincipal;
       setName(editor.property.name);
       setValue(candyValue);
@@ -52,7 +52,7 @@ export const PrincipalForm = (editor: CandyClassEditor) => {
   }, [editor.editorMode]);
 
   useEffect(() => {
-    if (editor.editorMode === 'edit') {
+    if (editor.editorMode === EDIT_MODE) {
       editor.editExistingProperty({
         name: name,
         value: value,
@@ -63,7 +63,7 @@ export const PrincipalForm = (editor: CandyClassEditor) => {
 
   return (
     <>
-      {editor.editorMode === 'create' ? (
+      {editor.editorMode === CREATE_MODE ? (
         <>
           <Flex>
             <TextInput label="Name" onChange={onNameChanged} />

--- a/packages/candy_editor/src/assets/formTypes/PrincipalForm/principalForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/PrincipalForm/principalForm.tsx
@@ -11,7 +11,6 @@ export const PrincipalForm = (editor: CandyClassEditor) => {
   const [immutable, setImmutable] = useState<boolean>(false);
   const [isInvalid, setIsInvalid] = useState<boolean>(false);
   const [validationError, setValidationError] = useState<string>(null);
-  const [isRemoved, setIsRemoved] = useState<boolean>(false);
 
   const onNameChanged = (typedName: React.ChangeEvent<HTMLInputElement>) => {
     setName(typedName.target.value);
@@ -32,10 +31,6 @@ export const PrincipalForm = (editor: CandyClassEditor) => {
       setIsInvalid(true);
       setValidationError(VALIDATION_ERRORS.principal);
     }
-  };
-
-  const onRemove = (): void => {
-    setIsRemoved(true);
   };
 
   const saveProperty = () => {
@@ -65,10 +60,6 @@ export const PrincipalForm = (editor: CandyClassEditor) => {
       });
     }
   }, [name, value, immutable]);
-
-  useEffect(() => {
-    if (editor.editorMode === 'edit') editor.removePropertyFromCandyClass(editor.property);
-  }, [isRemoved]);
 
   return (
     <>
@@ -126,15 +117,6 @@ export const PrincipalForm = (editor: CandyClassEditor) => {
               </Grid>
               <Grid column={3}>
                 <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
-              </Grid>
-              <Grid column={4}>
-                <Flex>
-                  <span style={{ marginTop: 'auto', marginBottom: 'auto' }}>
-                    <Button size="small" btnType="filled" onClick={onRemove}>
-                      Remove CandyValue
-                    </Button>
-                  </span>
-                </Flex>
               </Grid>
             </>
           )}

--- a/packages/candy_editor/src/assets/formTypes/TextForm/textForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/TextForm/textForm.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Flex, TextInput, CheckboxInput, Button, HR } from '@origyn-sa/origyn-art-ui';
+import { Flex, TextInput, CheckboxInput, Button, Grid } from '@origyn-sa/origyn-art-ui';
 import type { CandyClassEditor, CandyText } from '../../../types';
 
 export const TextForm = (editor: CandyClassEditor) => {
@@ -60,7 +60,6 @@ export const TextForm = (editor: CandyClassEditor) => {
 
   return (
     <>
-      <HR marginTop={8} marginBottom={16} />
       {editor.editorMode === 'create' ? (
         <>
           <Flex>
@@ -86,41 +85,47 @@ export const TextForm = (editor: CandyClassEditor) => {
         <>
           {editor.property.immutable ? (
             <>
-              <Flex>
+              <Grid column={1}>
                 <TextInput
-                  label="Name"
-                  onChange={onNameChanged}
                   value={name}
                   disabled={immutable}
                 />
-              </Flex>
-              <Flex>
+              </Grid>
+              <Grid column={2}>
                 <TextInput
-                  label="Value"
-                  onChange={onValueChanged}
                   value={value.Text}
                   disabled={immutable}
                 />
-              </Flex>
+              </Grid>
+              <Grid column={3}>
+                <span>Property is immutable</span>
+              </Grid>
+              <Grid column={4}>
+                <span>Property is immutable</span>
+              </Grid>
             </>
           ) : (
             <>
-              <Flex>
-                <TextInput label="Name" onChange={onNameChanged} value={name} />
-              </Flex>
-              <Flex>
-                <TextInput label="Value" onChange={onValueChanged} value={value.Text} />
-              </Flex>
-              <Flex>
+              <Grid column={1}>
+                <TextInput onChange={onNameChanged} value={name} />
+              </Grid>
+              <Grid column={2}>
+                <TextInput onChange={onValueChanged} value={formValue} />
+              </Grid>
+              <Grid column={3}>
                 <Flex>
                   <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
                 </Flex>
-              </Flex>
-              <Flex>
-                <Button size="small" btnType="filled" onClick={onRemove}>
-                  Remove CandyValue
-                </Button>
-              </Flex>
+              </Grid>
+              <Grid column={4}>
+                <Flex>
+                  <span style={{ marginTop: 'auto', marginBottom: 'auto' }}>
+                    <Button size="small" btnType="filled" onClick={onRemove}>
+                      Remove CandyValue
+                    </Button>
+                  </span>
+                </Flex>
+              </Grid>
             </>
           )}
         </>

--- a/packages/candy_editor/src/assets/formTypes/TextForm/textForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/TextForm/textForm.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import { Flex, TextInput, CheckboxInput, Button, HR } from '@origyn-sa/origyn-art-ui';
-import type { CandyClassEditor, CandyText, Property } from '../../../types';
+import type { CandyClassEditor, CandyText } from '../../../types';
 
 export const TextForm = (editor: CandyClassEditor) => {
   const [name, setName] = useState<string>('');
   const [value, setValue] = useState<CandyText>({ Text: '' });
+  const [formValue, setFormValue] = useState<string>('');
   const [immutable, setImmutable] = useState<boolean>(false);
   const [isRemoved, setIsRemoved] = useState<boolean>(false);
 
@@ -18,6 +19,7 @@ export const TextForm = (editor: CandyClassEditor) => {
 
   const onValueChanged = (typedValue: React.ChangeEvent<HTMLInputElement>): void => {
     setValue({ Text: typedValue.target.value });
+    setFormValue(typedValue.target.value);
   };
 
   const onRemove = (): void => {
@@ -38,6 +40,7 @@ export const TextForm = (editor: CandyClassEditor) => {
       setName(editor.property.name);
       setValue(CandyValue);
       setImmutable(editor.property.immutable);
+      setFormValue(CandyValue.Text);
     }
   }, [editor.editorMode]);
 
@@ -64,7 +67,7 @@ export const TextForm = (editor: CandyClassEditor) => {
             <TextInput label="Name" onChange={onNameChanged} value={name} />
           </Flex>
           <Flex>
-            <TextInput label="Value" onChange={onValueChanged} value={value.Text} />
+            <TextInput label="Value" onChange={onValueChanged} value={formValue} />
           </Flex>
           <Flex>
             <Flex>

--- a/packages/candy_editor/src/assets/formTypes/TextForm/textForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/TextForm/textForm.tsx
@@ -36,11 +36,11 @@ export const TextForm = (editor: CandyClassEditor) => {
 
   useEffect(() => {
     if (editor.editorMode === 'edit') {
-      const CandyValue = editor.property.value as CandyText;
+      const candyValue = editor.property.value as CandyText;
       setName(editor.property.name);
-      setValue(CandyValue);
+      setValue(candyValue);
       setImmutable(editor.property.immutable);
-      setFormValue(CandyValue.Text);
+      setFormValue(candyValue.Text);
     }
   }, [editor.editorMode]);
 

--- a/packages/candy_editor/src/assets/formTypes/TextForm/textForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/TextForm/textForm.tsx
@@ -1,11 +1,10 @@
-import React, { useState } from 'react';
-import { Flex, Container, TextInput, CheckboxInput, Button, HR } from '@origyn-sa/origyn-art-ui';
-import type { CandyClassEditor,CandyText } from '../../../types';
+import React, { useEffect, useState } from 'react';
+import { Flex, TextInput, CheckboxInput, Button, HR } from '@origyn-sa/origyn-art-ui';
+import type { CandyClassEditor, CandyText } from '../../../types';
 
-export const TextForm = (editor : CandyClassEditor) => {
-  
+export const TextForm = (editor: CandyClassEditor) => {
   const [name, setName] = useState<string>('');
-  const [value, setValue] = useState<CandyText>();
+  const [value, setValue] = useState<CandyText>({ Text: '' });
   const [immutable, setImmutable] = useState<boolean>(false);
 
   const onNameChanged = (typedName: React.ChangeEvent<HTMLInputElement>) => {
@@ -21,34 +20,52 @@ export const TextForm = (editor : CandyClassEditor) => {
   };
 
   const saveProperty = () => {
-    editor.addPropertyToCandyClass({
-        name: name,
-        value: value,
-        immutable: immutable,
-    });
+    switch (editor.editorMode) {
+      case 'create':
+        editor.addPropertyToCandyClass({
+          name: name,
+          value: value,
+          immutable: immutable,
+        });
+        break;
+      case 'edit':
+        alert('edit');
+    }
   };
 
+  useEffect(() => {
+    if (editor.editorMode === 'edit') {
+      const CandyValue = editor.property.value as CandyText;
+      setName(editor.property.name);
+      setValue(CandyValue);
+    }
+  }, [editor.editorMode]);
+
   return (
-    <Container>
-      <Flex flexFlow="row" gap={16}>
+    <>
+      <Flex>
+        <TextInput label="Name" onChange={onNameChanged} value={name} />
+      </Flex>
+      <Flex>
+        <TextInput label="Value" onChange={onValueChanged} value={value.Text} />
+      </Flex>
+      <Flex>
         <Flex>
-          <TextInput label="Name" onChange={onNameChanged} />
-        </Flex>
-        <Flex>
-          <TextInput label="Value" onChange={onValueChanged} />
-        </Flex>
-        <Flex>
-          <Flex>
-            <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
-          </Flex>
+          <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
         </Flex>
       </Flex>
       <HR marginTop={8} marginBottom={16} />
-      <Flex>
-        <Button size="small" btnType="filled" onClick={saveProperty}>
-          Save Property
-        </Button>
-      </Flex>
-    </Container>
+      {editor.editorMode === 'create' ? (
+        <Flex>
+          <span>
+            <Button size="small" btnType="filled" onClick={saveProperty}>
+              Save
+            </Button>
+          </span>
+        </Flex>
+      ) : (
+        <></>
+      )}
+    </>
   );
 };

--- a/packages/candy_editor/src/assets/formTypes/TextForm/textForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/TextForm/textForm.tsx
@@ -86,16 +86,10 @@ export const TextForm = (editor: CandyClassEditor) => {
           {editor.property.immutable ? (
             <>
               <Grid column={1}>
-                <TextInput
-                  value={name}
-                  disabled={immutable}
-                />
+                <TextInput value={name} disabled={true} />
               </Grid>
               <Grid column={2}>
-                <TextInput
-                  value={value.Text}
-                  disabled={immutable}
-                />
+                <TextInput value={value.Text} disabled={true} />
               </Grid>
               <Grid column={3}>
                 <span>Property is immutable</span>

--- a/packages/candy_editor/src/assets/formTypes/TextForm/textForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/TextForm/textForm.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Flex, TextInput, CheckboxInput, Button, Grid } from '@origyn-sa/origyn-art-ui';
-import type { CandyClassEditor, CandyText } from '../../../types';
+import { CandyClassEditor, CandyText } from '../../../types';
 import { CREATE_MODE, EDIT_MODE } from '../../../constants';
 
 export const TextForm = (editor: CandyClassEditor) => {
@@ -11,15 +11,30 @@ export const TextForm = (editor: CandyClassEditor) => {
 
   const onNameChanged = (typedName: React.ChangeEvent<HTMLInputElement>): void => {
     setName(typedName.target.value);
+    if (editor.editorMode === EDIT_MODE) {
+      editor.editExistingProperty(
+        { name: typedName.target.value, value, immutable },
+        editor.propertyIndex,
+      );
+    }
   };
 
   const onImmutableChanged = (): void => {
     setImmutable(!immutable);
+    if (editor.editorMode === EDIT_MODE) {
+      editor.editExistingProperty({ name, value, immutable: !immutable }, editor.propertyIndex);
+    }
   };
 
   const onValueChanged = (typedValue: React.ChangeEvent<HTMLInputElement>): void => {
     setValue({ Text: typedValue.target.value });
     setFormValue(typedValue.target.value);
+    if (editor.editorMode === EDIT_MODE) {
+      editor.editExistingProperty(
+        { name, value: { Text: typedValue.target.value }, immutable },
+        editor.propertyIndex,
+      );
+    }
   };
 
   const saveProperty = (): void => {
@@ -27,6 +42,7 @@ export const TextForm = (editor: CandyClassEditor) => {
       name: name,
       value: value,
       immutable: immutable,
+      id: Math.random().toString(),
     });
   };
 
@@ -35,8 +51,8 @@ export const TextForm = (editor: CandyClassEditor) => {
       const candyValue = editor.property.value as CandyText;
       setName(editor.property.name);
       setValue(candyValue);
-      setImmutable(editor.property.immutable);
       setFormValue(candyValue.Text);
+      setImmutable(editor.property.immutable);
     }
   }, [editor.editorMode]);
 
@@ -71,7 +87,7 @@ export const TextForm = (editor: CandyClassEditor) => {
                 <TextInput value={name} disabled={true} />
               </Grid>
               <Grid column={2}>
-                <TextInput value={value.Text} disabled={true} />
+                <TextInput value={formValue} disabled={true} />
               </Grid>
               <Grid column={3}>
                 <span>Property is immutable</span>

--- a/packages/candy_editor/src/assets/formTypes/TextForm/textForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/TextForm/textForm.tsx
@@ -103,14 +103,7 @@ export const TextForm = (editor: CandyClassEditor) => {
           ) : (
             <>
               <Flex>
-                <TextInput
-                  label="Name"
-                  onChange={onNameChanged}
-                  value={name}
-                  error={
-                    'This is an Error This is an Error This is an ErrorThis is an Error This is an Error This is an Error'
-                  }
-                />
+                <TextInput label="Name" onChange={onNameChanged} value={name} />
               </Flex>
               <Flex>
                 <TextInput label="Value" onChange={onValueChanged} value={value.Text} />

--- a/packages/candy_editor/src/assets/formTypes/TextForm/textForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/TextForm/textForm.tsx
@@ -1,36 +1,35 @@
 import React, { useEffect, useState } from 'react';
 import { Flex, TextInput, CheckboxInput, Button, HR } from '@origyn-sa/origyn-art-ui';
-import type { CandyClassEditor, CandyText } from '../../../types';
+import type { CandyClassEditor, CandyText, Property } from '../../../types';
 
 export const TextForm = (editor: CandyClassEditor) => {
   const [name, setName] = useState<string>('');
   const [value, setValue] = useState<CandyText>({ Text: '' });
   const [immutable, setImmutable] = useState<boolean>(false);
+  const [isRemoved, setIsRemoved] = useState<boolean>(false);
 
-  const onNameChanged = (typedName: React.ChangeEvent<HTMLInputElement>) => {
+  const onNameChanged = (typedName: React.ChangeEvent<HTMLInputElement>): void => {
     setName(typedName.target.value);
   };
 
-  const onImmutableChanged = () => {
+  const onImmutableChanged = (): void => {
     setImmutable(!immutable);
   };
 
-  const onValueChanged = (typedValue: React.ChangeEvent<HTMLInputElement>) => {
+  const onValueChanged = (typedValue: React.ChangeEvent<HTMLInputElement>): void => {
     setValue({ Text: typedValue.target.value });
   };
 
-  const saveProperty = () => {
-    switch (editor.editorMode) {
-      case 'create':
-        editor.addPropertyToCandyClass({
-          name: name,
-          value: value,
-          immutable: immutable,
-        });
-        break;
-      case 'edit':
-        alert('edit');
-    }
+  const onRemove = (): void => {
+    setIsRemoved(true);
+  };
+
+  const saveProperty = (): void => {
+    editor.addPropertyToCandyClass({
+      name: name,
+      value: value,
+      immutable: immutable,
+    });
   };
 
   useEffect(() => {
@@ -38,33 +37,97 @@ export const TextForm = (editor: CandyClassEditor) => {
       const CandyValue = editor.property.value as CandyText;
       setName(editor.property.name);
       setValue(CandyValue);
+      setImmutable(editor.property.immutable);
     }
   }, [editor.editorMode]);
 
+  useEffect(() => {
+    if (editor.editorMode === 'edit') {
+      editor.editExistingProperty({
+        name: name,
+        value: value,
+        immutable: immutable,
+      });
+    }
+  }, [name, value, immutable]);
+
+  useEffect(() => {
+    if (editor.editorMode === 'edit') editor.removePropertyFromCandyClass(editor.property);
+  }, [isRemoved]);
+
   return (
     <>
-      <Flex>
-        <TextInput label="Name" onChange={onNameChanged} value={name} />
-      </Flex>
-      <Flex>
-        <TextInput label="Value" onChange={onValueChanged} value={value.Text} />
-      </Flex>
-      <Flex>
-        <Flex>
-          <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
-        </Flex>
-      </Flex>
       <HR marginTop={8} marginBottom={16} />
       {editor.editorMode === 'create' ? (
-        <Flex>
-          <span>
-            <Button size="small" btnType="filled" onClick={saveProperty}>
-              Save
-            </Button>
-          </span>
-        </Flex>
+        <>
+          <Flex>
+            <TextInput label="Name" onChange={onNameChanged} value={name} />
+          </Flex>
+          <Flex>
+            <TextInput label="Value" onChange={onValueChanged} value={value.Text} />
+          </Flex>
+          <Flex>
+            <Flex>
+              <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
+            </Flex>
+          </Flex>
+          <Flex>
+            <span>
+              <Button size="small" btnType="filled" onClick={saveProperty}>
+                Save
+              </Button>
+            </span>
+          </Flex>
+        </>
       ) : (
-        <></>
+        <>
+          {editor.property.immutable ? (
+            <>
+              <Flex>
+                <TextInput
+                  label="Name"
+                  onChange={onNameChanged}
+                  value={name}
+                  disabled={immutable}
+                />
+              </Flex>
+              <Flex>
+                <TextInput
+                  label="Value"
+                  onChange={onValueChanged}
+                  value={value.Text}
+                  disabled={immutable}
+                />
+              </Flex>
+            </>
+          ) : (
+            <>
+              <Flex>
+                <TextInput
+                  label="Name"
+                  onChange={onNameChanged}
+                  value={name}
+                  error={
+                    'This is an Error This is an Error This is an ErrorThis is an Error This is an Error This is an Error'
+                  }
+                />
+              </Flex>
+              <Flex>
+                <TextInput label="Value" onChange={onValueChanged} value={value.Text} />
+              </Flex>
+              <Flex>
+                <Flex>
+                  <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
+                </Flex>
+              </Flex>
+              <Flex>
+                <Button size="small" btnType="filled" onClick={onRemove}>
+                  Remove CandyValue
+                </Button>
+              </Flex>
+            </>
+          )}
+        </>
       )}
     </>
   );

--- a/packages/candy_editor/src/assets/formTypes/TextForm/textForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/TextForm/textForm.tsx
@@ -40,16 +40,6 @@ export const TextForm = (editor: CandyClassEditor) => {
     }
   }, [editor.editorMode]);
 
-  useEffect(() => {
-    if (editor.editorMode === EDIT_MODE) {
-      editor.editExistingProperty({
-        name: name,
-        value: value,
-        immutable: immutable,
-      });
-    }
-  }, [name, value, immutable]);
-
   return (
     <>
       {editor.editorMode === CREATE_MODE ? (

--- a/packages/candy_editor/src/assets/formTypes/TextForm/textForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/TextForm/textForm.tsx
@@ -7,7 +7,6 @@ export const TextForm = (editor: CandyClassEditor) => {
   const [value, setValue] = useState<CandyText>({ Text: '' });
   const [formValue, setFormValue] = useState<string>('');
   const [immutable, setImmutable] = useState<boolean>(false);
-  const [isRemoved, setIsRemoved] = useState<boolean>(false);
 
   const onNameChanged = (typedName: React.ChangeEvent<HTMLInputElement>): void => {
     setName(typedName.target.value);
@@ -20,10 +19,6 @@ export const TextForm = (editor: CandyClassEditor) => {
   const onValueChanged = (typedValue: React.ChangeEvent<HTMLInputElement>): void => {
     setValue({ Text: typedValue.target.value });
     setFormValue(typedValue.target.value);
-  };
-
-  const onRemove = (): void => {
-    setIsRemoved(true);
   };
 
   const saveProperty = (): void => {
@@ -53,10 +48,6 @@ export const TextForm = (editor: CandyClassEditor) => {
       });
     }
   }, [name, value, immutable]);
-
-  useEffect(() => {
-    if (editor.editorMode === 'edit') editor.removePropertyFromCandyClass(editor.property);
-  }, [isRemoved]);
 
   return (
     <>
@@ -109,15 +100,6 @@ export const TextForm = (editor: CandyClassEditor) => {
               <Grid column={3}>
                 <Flex>
                   <CheckboxInput label="Immutable" name="immutable" onChange={onImmutableChanged} />
-                </Flex>
-              </Grid>
-              <Grid column={4}>
-                <Flex>
-                  <span style={{ marginTop: 'auto', marginBottom: 'auto' }}>
-                    <Button size="small" btnType="filled" onClick={onRemove}>
-                      Remove CandyValue
-                    </Button>
-                  </span>
                 </Flex>
               </Grid>
             </>

--- a/packages/candy_editor/src/assets/formTypes/TextForm/textForm.tsx
+++ b/packages/candy_editor/src/assets/formTypes/TextForm/textForm.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Flex, TextInput, CheckboxInput, Button, Grid } from '@origyn-sa/origyn-art-ui';
 import type { CandyClassEditor, CandyText } from '../../../types';
+import { CREATE_MODE, EDIT_MODE } from '../../../constants';
 
 export const TextForm = (editor: CandyClassEditor) => {
   const [name, setName] = useState<string>('');
@@ -30,7 +31,7 @@ export const TextForm = (editor: CandyClassEditor) => {
   };
 
   useEffect(() => {
-    if (editor.editorMode === 'edit') {
+    if (editor.editorMode === EDIT_MODE) {
       const candyValue = editor.property.value as CandyText;
       setName(editor.property.name);
       setValue(candyValue);
@@ -40,7 +41,7 @@ export const TextForm = (editor: CandyClassEditor) => {
   }, [editor.editorMode]);
 
   useEffect(() => {
-    if (editor.editorMode === 'edit') {
+    if (editor.editorMode === EDIT_MODE) {
       editor.editExistingProperty({
         name: name,
         value: value,
@@ -51,7 +52,7 @@ export const TextForm = (editor: CandyClassEditor) => {
 
   return (
     <>
-      {editor.editorMode === 'create' ? (
+      {editor.editorMode === CREATE_MODE ? (
         <>
           <Flex>
             <TextInput label="Name" onChange={onNameChanged} value={name} />

--- a/packages/candy_editor/src/assets/formTypes/index.tsx
+++ b/packages/candy_editor/src/assets/formTypes/index.tsx
@@ -15,7 +15,6 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
-      removePropertyFromCandyClass={props.removePropertyFromCandyClass}
     />
   ),
   Nat: (props: CandyClassEditor) => (
@@ -25,7 +24,6 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
-      removePropertyFromCandyClass={props.removePropertyFromCandyClass}
     />
   ),
   Nat8: (props: CandyClassEditor) => (
@@ -35,7 +33,6 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
-      removePropertyFromCandyClass={props.removePropertyFromCandyClass}
     />
   ),
   Nat16: (props: CandyClassEditor) => (
@@ -45,7 +42,6 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
-      removePropertyFromCandyClass={props.removePropertyFromCandyClass}
     />
   ),
   Nat32: (props: CandyClassEditor) => (
@@ -55,7 +51,6 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
-      removePropertyFromCandyClass={props.removePropertyFromCandyClass}
     />
   ),
   Nat64: (props: CandyClassEditor) => (
@@ -65,7 +60,6 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
-      removePropertyFromCandyClass={props.removePropertyFromCandyClass}
     />
   ),
   Int: (props: CandyClassEditor) => (
@@ -75,7 +69,6 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
-      removePropertyFromCandyClass={props.removePropertyFromCandyClass}
     />
   ),
   Int8: (props: CandyClassEditor) => (
@@ -85,7 +78,6 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
-      removePropertyFromCandyClass={props.removePropertyFromCandyClass}
     />
   ),
   Int16: (props: CandyClassEditor) => (
@@ -95,7 +87,6 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
-      removePropertyFromCandyClass={props.removePropertyFromCandyClass}
     />
   ),
   Int32: (props: CandyClassEditor) => (
@@ -105,7 +96,6 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
-      removePropertyFromCandyClass={props.removePropertyFromCandyClass}
     />
   ),
   Int64: (props: CandyClassEditor) => (
@@ -115,7 +105,6 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
-      removePropertyFromCandyClass={props.removePropertyFromCandyClass}
     />
   ),
   Bool: (props: CandyClassEditor) => (
@@ -125,7 +114,6 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
-      removePropertyFromCandyClass={props.removePropertyFromCandyClass}
     />
   ),
   Float: (props: CandyClassEditor) => (
@@ -135,7 +123,6 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
-      removePropertyFromCandyClass={props.removePropertyFromCandyClass}
     />
   ),
   Principal: (props: CandyClassEditor) => (
@@ -145,7 +132,6 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
-      removePropertyFromCandyClass={props.removePropertyFromCandyClass}
     />
   ),
 };

--- a/packages/candy_editor/src/assets/formTypes/index.tsx
+++ b/packages/candy_editor/src/assets/formTypes/index.tsx
@@ -9,45 +9,129 @@ import { PrincipalForm } from './PrincipalForm/principalForm';
 
 export const FormTypes = {
   Text: (props: CandyClassEditor) => (
-    <TextForm addPropertyToCandyClass={props.addPropertyToCandyClass} candyType={props.candyType} />
+    <TextForm
+      addPropertyToCandyClass={props.addPropertyToCandyClass}
+      candyType={props.candyType}
+      editExistingProperty={props.editExistingProperty}
+      editorMode={props.editorMode}
+      property={props.property}
+    />
   ),
   Nat: (props: CandyClassEditor) => (
-    <NaturalsForm addPropertyToCandyClass={props.addPropertyToCandyClass} candyType={props.candyType} />
+    <NaturalsForm
+      addPropertyToCandyClass={props.addPropertyToCandyClass}
+      candyType={props.candyType}
+      editExistingProperty={props.editExistingProperty}
+      editorMode={props.editorMode}
+      property={props.property}
+    />
   ),
   Nat8: (props: CandyClassEditor) => (
-    <NaturalsForm addPropertyToCandyClass={props.addPropertyToCandyClass} candyType={props.candyType} />
+    <NaturalsForm
+      addPropertyToCandyClass={props.addPropertyToCandyClass}
+      candyType={props.candyType}
+      editExistingProperty={props.editExistingProperty}
+      editorMode={props.editorMode}
+      property={props.property}
+    />
   ),
   Nat16: (props: CandyClassEditor) => (
-    <NaturalsForm addPropertyToCandyClass={props.addPropertyToCandyClass} candyType={props.candyType} />
+    <NaturalsForm
+      addPropertyToCandyClass={props.addPropertyToCandyClass}
+      candyType={props.candyType}
+      editExistingProperty={props.editExistingProperty}
+      editorMode={props.editorMode}
+      property={props.property}
+    />
   ),
   Nat32: (props: CandyClassEditor) => (
-    <NaturalsForm addPropertyToCandyClass={props.addPropertyToCandyClass} candyType={props.candyType} />
+    <NaturalsForm
+      addPropertyToCandyClass={props.addPropertyToCandyClass}
+      candyType={props.candyType}
+      editExistingProperty={props.editExistingProperty}
+      editorMode={props.editorMode}
+      property={props.property}
+    />
   ),
   Nat64: (props: CandyClassEditor) => (
-    <NaturalsForm addPropertyToCandyClass={props.addPropertyToCandyClass} candyType={props.candyType} />
+    <NaturalsForm
+      addPropertyToCandyClass={props.addPropertyToCandyClass}
+      candyType={props.candyType}
+      editExistingProperty={props.editExistingProperty}
+      editorMode={props.editorMode}
+      property={props.property}
+    />
   ),
   Int: (props: CandyClassEditor) => (
-    <IntegersForm addPropertyToCandyClass={props.addPropertyToCandyClass} candyType={props.candyType} />
+    <IntegersForm
+      addPropertyToCandyClass={props.addPropertyToCandyClass}
+      candyType={props.candyType}
+      editExistingProperty={props.editExistingProperty}
+      editorMode={props.editorMode}
+      property={props.property}
+    />
   ),
   Int8: (props: CandyClassEditor) => (
-    <IntegersForm addPropertyToCandyClass={props.addPropertyToCandyClass} candyType={props.candyType} />
+    <IntegersForm
+      addPropertyToCandyClass={props.addPropertyToCandyClass}
+      candyType={props.candyType}
+      editExistingProperty={props.editExistingProperty}
+      editorMode={props.editorMode}
+      property={props.property}
+    />
   ),
   Int16: (props: CandyClassEditor) => (
-    <IntegersForm addPropertyToCandyClass={props.addPropertyToCandyClass} candyType={props.candyType} />
+    <IntegersForm
+      addPropertyToCandyClass={props.addPropertyToCandyClass}
+      candyType={props.candyType}
+      editExistingProperty={props.editExistingProperty}
+      editorMode={props.editorMode}
+      property={props.property}
+    />
   ),
   Int32: (props: CandyClassEditor) => (
-    <IntegersForm addPropertyToCandyClass={props.addPropertyToCandyClass} candyType={props.candyType} />
+    <IntegersForm
+      addPropertyToCandyClass={props.addPropertyToCandyClass}
+      candyType={props.candyType}
+      editExistingProperty={props.editExistingProperty}
+      editorMode={props.editorMode}
+      property={props.property}
+    />
   ),
   Int64: (props: CandyClassEditor) => (
-    <IntegersForm addPropertyToCandyClass={props.addPropertyToCandyClass} candyType={props.candyType} />
+    <IntegersForm
+      addPropertyToCandyClass={props.addPropertyToCandyClass}
+      candyType={props.candyType}
+      editExistingProperty={props.editExistingProperty}
+      editorMode={props.editorMode}
+      property={props.property}
+    />
   ),
   Bool: (props: CandyClassEditor) => (
-    <BoolForm addPropertyToCandyClass={props.addPropertyToCandyClass} candyType={props.candyType} />
+    <BoolForm
+      addPropertyToCandyClass={props.addPropertyToCandyClass}
+      candyType={props.candyType}
+      editExistingProperty={props.editExistingProperty}
+      editorMode={props.editorMode}
+      property={props.property}
+    />
   ),
   Float: (props: CandyClassEditor) => (
-    <FloatForm addPropertyToCandyClass={props.addPropertyToCandyClass} candyType={props.candyType} />
+    <FloatForm
+      addPropertyToCandyClass={props.addPropertyToCandyClass}
+      candyType={props.candyType}
+      editExistingProperty={props.editExistingProperty}
+      editorMode={props.editorMode}
+      property={props.property}
+    />
   ),
   Principal: (props: CandyClassEditor) => (
-    <PrincipalForm addPropertyToCandyClass={props.addPropertyToCandyClass} candyType={props.candyType} />
+    <PrincipalForm
+      addPropertyToCandyClass={props.addPropertyToCandyClass}
+      candyType={props.candyType}
+      editExistingProperty={props.editExistingProperty}
+      editorMode={props.editorMode}
+      property={props.property}
+    />
   ),
 };

--- a/packages/candy_editor/src/assets/formTypes/index.tsx
+++ b/packages/candy_editor/src/assets/formTypes/index.tsx
@@ -25,6 +25,7 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
+      removePropertyFromCandyClass={props.removePropertyFromCandyClass}
     />
   ),
   Nat8: (props: CandyClassEditor) => (
@@ -34,6 +35,7 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
+      removePropertyFromCandyClass={props.removePropertyFromCandyClass}
     />
   ),
   Nat16: (props: CandyClassEditor) => (
@@ -43,6 +45,7 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
+      removePropertyFromCandyClass={props.removePropertyFromCandyClass}
     />
   ),
   Nat32: (props: CandyClassEditor) => (
@@ -52,6 +55,7 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
+      removePropertyFromCandyClass={props.removePropertyFromCandyClass}
     />
   ),
   Nat64: (props: CandyClassEditor) => (
@@ -61,6 +65,8 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
+      removePropertyFromCandyClass={props.removePropertyFromCandyClass}
+
     />
   ),
   Int: (props: CandyClassEditor) => (

--- a/packages/candy_editor/src/assets/formTypes/index.tsx
+++ b/packages/candy_editor/src/assets/formTypes/index.tsx
@@ -15,6 +15,7 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
+      propertyIndex={props.propertyIndex}
     />
   ),
   Nat: (props: CandyClassEditor) => (
@@ -24,6 +25,7 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
+      propertyIndex={props.propertyIndex}
     />
   ),
   Nat8: (props: CandyClassEditor) => (
@@ -33,6 +35,7 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
+      propertyIndex={props.propertyIndex}
     />
   ),
   Nat16: (props: CandyClassEditor) => (
@@ -42,6 +45,7 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
+      propertyIndex={props.propertyIndex}
     />
   ),
   Nat32: (props: CandyClassEditor) => (
@@ -51,6 +55,7 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
+      propertyIndex={props.propertyIndex}
     />
   ),
   Nat64: (props: CandyClassEditor) => (
@@ -60,6 +65,7 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
+      propertyIndex={props.propertyIndex}
     />
   ),
   Int: (props: CandyClassEditor) => (
@@ -69,6 +75,7 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
+      propertyIndex={props.propertyIndex}
     />
   ),
   Int8: (props: CandyClassEditor) => (
@@ -78,6 +85,7 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
+      propertyIndex={props.propertyIndex}
     />
   ),
   Int16: (props: CandyClassEditor) => (
@@ -87,6 +95,7 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
+      propertyIndex={props.propertyIndex}
     />
   ),
   Int32: (props: CandyClassEditor) => (
@@ -96,6 +105,7 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
+      propertyIndex={props.propertyIndex}
     />
   ),
   Int64: (props: CandyClassEditor) => (
@@ -105,6 +115,7 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
+      propertyIndex={props.propertyIndex}
     />
   ),
   Bool: (props: CandyClassEditor) => (
@@ -114,6 +125,7 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
+      propertyIndex={props.propertyIndex}
     />
   ),
   Float: (props: CandyClassEditor) => (
@@ -123,6 +135,7 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
+      propertyIndex={props.propertyIndex}
     />
   ),
   Principal: (props: CandyClassEditor) => (
@@ -132,6 +145,7 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
+      propertyIndex={props.propertyIndex}
     />
   ),
 };

--- a/packages/candy_editor/src/assets/formTypes/index.tsx
+++ b/packages/candy_editor/src/assets/formTypes/index.tsx
@@ -120,6 +120,7 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
+      removePropertyFromCandyClass={props.removePropertyFromCandyClass}
     />
   ),
   Float: (props: CandyClassEditor) => (
@@ -129,6 +130,7 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
+      removePropertyFromCandyClass={props.removePropertyFromCandyClass}
     />
   ),
   Principal: (props: CandyClassEditor) => (
@@ -138,6 +140,7 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
+      removePropertyFromCandyClass={props.removePropertyFromCandyClass}
     />
   ),
 };

--- a/packages/candy_editor/src/assets/formTypes/index.tsx
+++ b/packages/candy_editor/src/assets/formTypes/index.tsx
@@ -70,6 +70,7 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
+      removePropertyFromCandyClass={props.removePropertyFromCandyClass}
     />
   ),
   Int8: (props: CandyClassEditor) => (
@@ -79,6 +80,7 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
+      removePropertyFromCandyClass={props.removePropertyFromCandyClass}
     />
   ),
   Int16: (props: CandyClassEditor) => (
@@ -88,6 +90,7 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
+      removePropertyFromCandyClass={props.removePropertyFromCandyClass}
     />
   ),
   Int32: (props: CandyClassEditor) => (
@@ -97,6 +100,7 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
+      removePropertyFromCandyClass={props.removePropertyFromCandyClass}
     />
   ),
   Int64: (props: CandyClassEditor) => (
@@ -106,6 +110,7 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
+      removePropertyFromCandyClass={props.removePropertyFromCandyClass}
     />
   ),
   Bool: (props: CandyClassEditor) => (

--- a/packages/candy_editor/src/assets/formTypes/index.tsx
+++ b/packages/candy_editor/src/assets/formTypes/index.tsx
@@ -15,6 +15,7 @@ export const FormTypes = {
       editExistingProperty={props.editExistingProperty}
       editorMode={props.editorMode}
       property={props.property}
+      removePropertyFromCandyClass={props.removePropertyFromCandyClass}
     />
   ),
   Nat: (props: CandyClassEditor) => (

--- a/packages/candy_editor/src/assets/formTypes/index.tsx
+++ b/packages/candy_editor/src/assets/formTypes/index.tsx
@@ -66,7 +66,6 @@ export const FormTypes = {
       editorMode={props.editorMode}
       property={props.property}
       removePropertyFromCandyClass={props.removePropertyFromCandyClass}
-
     />
   ),
   Int: (props: CandyClassEditor) => (

--- a/packages/candy_editor/src/assets/index.tsx
+++ b/packages/candy_editor/src/assets/index.tsx
@@ -1,10 +1,17 @@
 import React, { useEffect, useState } from 'react';
 import { Card, Flex, Grid, Button, HR, Select, Container, Modal } from '@origyn-sa/origyn-art-ui';
 import { FormTypes } from './formTypes';
-import type { Property, CandyClassEditor, CandyClass, CandyType, EditorMode, PropertyWithId, EditableCandyClass } from '../types';
+import type {
+  Property,
+  CandyClassEditor,
+  CandyClass,
+  CandyType,
+  EditorMode,
+  PropertyWithId,
+  EditableCandyClass,
+} from '../types';
 import { getValueType } from '../utils/functions';
 import { NOT_SELECTED, SELECT_OPTIONS, CREATE_MODE, EDIT_MODE } from '../constants';
-
 
 export const CandyDataEditor = () => {
   const [candyType, setCandyType] = useState<CandyType>(NOT_SELECTED);
@@ -41,7 +48,7 @@ export const CandyDataEditor = () => {
   };
 
   const editExistingProperty = (updatedProperty: Property, propertyIndex: number) => {
-    console.log('🚀 UPDATED PROPERTY #' + propertyIndex, updatedProperty)
+    console.log('🚀 UPDATED PROPERTY #' + propertyIndex, updatedProperty);
     const updated = editableCandyClass.Class.map((property, index) => {
       if (index === propertyIndex) {
         return { ...property, ...updatedProperty };
@@ -49,7 +56,7 @@ export const CandyDataEditor = () => {
       return property;
     });
     setEditableCandyClass({ Class: updated });
-  }
+  };
 
   const createEditCandyClassEditor = (
     candyType: string,
@@ -59,7 +66,8 @@ export const CandyDataEditor = () => {
     return {
       candyType,
       editorMode,
-      editExistingProperty: (updatedProperty: Property) => editExistingProperty(updatedProperty, propertyIndex),
+      editExistingProperty: (updatedProperty: Property) =>
+        editExistingProperty(updatedProperty, propertyIndex),
       property,
     };
   };
@@ -86,7 +94,7 @@ export const CandyDataEditor = () => {
         name: propertyWithId.name,
         immutable: propertyWithId.immutable,
         value: propertyWithId.value,
-      }
+      };
       arrayProperty.push(property);
     });
     setCandyClass({ Class: arrayProperty });
@@ -98,7 +106,7 @@ export const CandyDataEditor = () => {
   }, [editableCandyClass]);
 
   useEffect(() => {
-    console.log('🍬 CANDYCLASS', candyClass)
+    console.log('🍬 CANDYCLASS', candyClass);
   }, [candyClass]);
 
   return (
@@ -162,7 +170,7 @@ export const CandyDataEditor = () => {
           ) : null}
         </Flex>
       </Container>
-      <Modal closeModal={closeModal} isOpened={openModal} mode="light" size="md">
+      <Modal closeModal={closeModal} isOpened={openModal} mode="light" size="lg">
         <Container size="full" padding="48px">
           <Flex flexFlow="column" gap={16}>
             <Flex>

--- a/packages/candy_editor/src/assets/index.tsx
+++ b/packages/candy_editor/src/assets/index.tsx
@@ -1,19 +1,20 @@
 import React, { useEffect, useState } from 'react';
 import { Card, Flex, Grid, Button, HR, Select, Container, Modal } from '@origyn-sa/origyn-art-ui';
 import { FormTypes } from './formTypes';
-import type { Property, CandyClassEditor, CandyClass, CandyType, EditorMode } from '../types';
+import type { Property, CandyClassEditor, CandyClass, CandyType, EditorMode, PropertyWithId, EditableCandyClass } from '../types';
 import { getValueType } from '../utils/functions';
 import { NOT_SELECTED, SELECT_OPTIONS, CREATE_MODE, EDIT_MODE } from '../constants';
+
 
 export const CandyDataEditor = () => {
   const [candyType, setCandyType] = useState<CandyType>(NOT_SELECTED);
   const [candyClass, setCandyClass] = useState<CandyClass>({ Class: [] });
-  const [editableCandyClass, setEditableCandyClass] = useState<CandyClass>({ Class: [] });
+  const [editableCandyClass, setEditableCandyClass] = useState<EditableCandyClass>({ Class: [] });
   const [openModal, setOpenModal] = useState<boolean>(false);
   const [editorMode, setEditorMode] = useState<EditorMode>(EDIT_MODE);
 
   const addCandyClassEditor: CandyClassEditor = {
-    addPropertyToCandyClass: (property: Property) => {
+    addPropertyToCandyClass: (property: PropertyWithId) => {
       setEditableCandyClass((previous) => {
         const newClass = [...previous.Class, property];
         return {
@@ -38,7 +39,9 @@ export const CandyDataEditor = () => {
       };
     });
   };
+
   const editExistingProperty = (updatedProperty: Property, propertyIndex: number) => {
+    console.log('🚀 UPDATED PROPERTY #' + propertyIndex, updatedProperty)
     const updated = editableCandyClass.Class.map((property, index) => {
       if (index === propertyIndex) {
         return { ...property, ...updatedProperty };
@@ -56,7 +59,7 @@ export const CandyDataEditor = () => {
     return {
       candyType,
       editorMode,
-      editExistingProperty: () => editExistingProperty(property, propertyIndex),
+      editExistingProperty: (updatedProperty: Property) => editExistingProperty(updatedProperty, propertyIndex),
       property,
     };
   };
@@ -77,7 +80,16 @@ export const CandyDataEditor = () => {
   };
 
   const saveCandyClass = (): void => {
-    setCandyClass(editableCandyClass);
+    let arrayProperty: Property[] = [];
+    editableCandyClass.Class.forEach((propertyWithId) => {
+      const property: Property = {
+        name: propertyWithId.name,
+        immutable: propertyWithId.immutable,
+        value: propertyWithId.value,
+      }
+      arrayProperty.push(property);
+    });
+    setCandyClass({ Class: arrayProperty });
   };
 
   useEffect(() => {
@@ -86,7 +98,7 @@ export const CandyDataEditor = () => {
   }, [editableCandyClass]);
 
   useEffect(() => {
-    console.log('CANDYCLASS', candyClass)
+    console.log('🍬 CANDYCLASS', candyClass)
   }, [candyClass]);
 
   return (
@@ -112,7 +124,7 @@ export const CandyDataEditor = () => {
                   const item = getValueType(property);
                   return (
                     <>
-                      <Grid columns={4} gap={16} key={property.name + index}>
+                      <Grid columns={4} gap={16} key={property.id}>
                         {FormTypes[item.type](
                           createEditCandyClassEditor(item.type, property, index),
                         )}
@@ -141,13 +153,9 @@ export const CandyDataEditor = () => {
               </>
               <Flex flexFlow="column" gap={24}>
                 <Flex align="flex-end" justify="flex-end">
-                  {editableCandyClass === candyClass ? null : (
-                    <>
-                      <Button size="medium" btnType="filled" onClick={() => saveCandyClass()}>
-                        Save Candy Class
-                      </Button>
-                    </>
-                  )}
+                  <Button size="medium" btnType="filled" onClick={() => saveCandyClass()}>
+                    Save Candy Class
+                  </Button>
                 </Flex>
               </Flex>
             </>

--- a/packages/candy_editor/src/assets/index.tsx
+++ b/packages/candy_editor/src/assets/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Card, Flex, Button, HR, Select, Container, Modal } from '@origyn-sa/origyn-art-ui';
+import { Card, Flex, Grid, Button, HR, Select, Container, Modal } from '@origyn-sa/origyn-art-ui';
 import { FormTypes } from './formTypes';
 import type { Property, CandyClassEditor, CandyClass, CandyType, EditorMode } from '../types';
 import { getValueType } from '../utils/functions';
@@ -36,10 +36,15 @@ export const CandyDataEditor = () => {
           return property;
         });
         setEditableCandyClass({ Class: updated });
+        setCandyClass({ Class: updated });
       },
       removePropertyFromCandyClass: (property: Property): void => {
-        const updated = candyClass.Class.filter((item) => item !== property);
+        const updated = candyClass.Class.filter((item, index) => index !== propertyIndex);
+        alert(propertyIndex);
+        setEditableCandyClass({ Class: updated });
+        console.log('editableCandyClass', editableCandyClass);
         setCandyClass({ Class: updated });
+        console.log('candyClass', candyClass)
       },
       property: property,
     };
@@ -83,14 +88,25 @@ export const CandyDataEditor = () => {
           {candyClass.Class.length > 0 ? (
             <>
               <HR marginTop={8} marginBottom={8} />
-              <Flex flexFlow="column" gap={24}>
+              <Grid columns={4} gap={16}>
+                <Flex>Property Name</Flex>
+                <Flex>Property Value</Flex>
+                <Flex>Immutable</Flex>
+                <Flex>Actions</Flex>
+              </Grid>
+              <>
                 {candyClass.Class.map((property, index) => (
-                  <Flex flexFlow="row" gap={24} key={index}>
-                    {FormTypes[getValueType(property).type](
-                      createEditCandyClassEditor(getValueType(property).type, property, index),
-                    )}
-                  </Flex>
+                  <>
+                    <Grid columns={4} gap={16}>
+                      {FormTypes[getValueType(property).type](
+                        createEditCandyClassEditor(getValueType(property).type, property, index),
+                      )}
+                    </Grid>
+                    <HR marginTop={8} marginBottom={8} />
+                  </>
                 ))}
+              </>
+              <Flex flexFlow="column" gap={24}>
                 <Flex align="flex-end" justify="flex-end">
                   {editableCandyClass === candyClass ? null : (
                     <>

--- a/packages/candy_editor/src/assets/index.tsx
+++ b/packages/candy_editor/src/assets/index.tsx
@@ -1,36 +1,58 @@
 import React, { useEffect, useState } from 'react';
 import { Card, Flex, Button, HR, Select, Container, Modal } from '@origyn-sa/origyn-art-ui';
 import { FormTypes } from './formTypes';
-import type { Property, CandyClassEditor, CandyClass, CandyType } from '../types';
+import type { Property, CandyClassEditor, CandyClass, CandyType, EditorMode } from '../types';
+import { getValueType } from '../utils/functions';
 import { NOT_SELECTED, SELECT_OPTIONS } from '../constants';
 
 export const CandyDataEditor = () => {
   const [candyType, setCandyType] = useState<CandyType>(NOT_SELECTED);
   const [candyClass, setCandyClass] = useState<CandyClass>({ Class: [] });
   const [openModal, setOpenModal] = useState<boolean>(false);
+  const [editorMode, setEditorMode] = useState<EditorMode>("edit");
 
-  const removePropertyFromCandyClass = (property: Property): void => {
-    const newClass = [...candyClass.Class];
-    const index = newClass.indexOf(property);
-    if (index !== -1) {
-      newClass.splice(index, 1);
-    }
-    setCandyClass({ Class: newClass });
-  };
-
-  const candyClassEditor: CandyClassEditor = {
+  const addCandyClassEditor: CandyClassEditor = {
     addPropertyToCandyClass: (property: Property) => {
       setCandyClass({ Class: [...candyClass.Class, property] });
     },
     candyType: candyType,
+    removePropertyFromCandyClass: (property: Property): void => {
+      const newClass = [...candyClass.Class];
+      const index = newClass.indexOf(property);
+      if (index !== -1) {
+        newClass.splice(index, 1);
+      }
+      setCandyClass({ Class: newClass });
+    },
+    editorMode: editorMode,
   };
+
+  const createEditCandyClassEditor = (candyType: string, property: Property, propIndex: number): CandyClassEditor => {
+    return {
+      candyType: candyType,
+      editorMode: editorMode,
+      editExistingProperty: (updatedProperty: Property,) => {
+        const updatedProperties = candyClass.Class.map((property, index) => {
+          if (index === propIndex) {
+            return { ...property, ...updatedProperty };
+          }
+          return property;
+        });
+        setCandyClass({ Class: updatedProperties });
+      },
+      property: property
+    }
+  }
 
   const displayModal = () => {
     setOpenModal(true);
+    setEditorMode("create")
   };
 
   const closeModal = () => {
     setOpenModal(false);
+    setCandyType(NOT_SELECTED);
+    setEditorMode("edit")
   };
 
   const handleSelectChange = (candySelectedType: CandyClass) => {
@@ -40,6 +62,7 @@ export const CandyDataEditor = () => {
   useEffect(() => {
     console.log('Candy Class', candyClass);
     setCandyType(NOT_SELECTED);
+    closeModal();
   }, [candyClass]);
 
   return (
@@ -54,49 +77,24 @@ export const CandyDataEditor = () => {
           {candyClass.Class.length > 0 ? (
             <>
               <HR marginTop={8} marginBottom={8} />
-              <Flex flexFlow="column" gap={16}>
-                {candyClass.Class.map((property, index) => (
-                  <Flex key={index} flexFlow="row" gap={8}>
-                    <Flex>
-                      <p>
-                        <b>Name: </b>
-                        {property.name}
-                      </p>
+              <Flex flexFlow="column" gap={24}>
+                {
+                  candyClass.Class.map((property, index) => (
+                    <Flex flexFlow="row" gap={24} key={index}>
+                      {
+                        FormTypes[getValueType(property).type](
+                          createEditCandyClassEditor(getValueType(property).type, property, index)
+                        )
+                      }
                     </Flex>
-                    <Flex>
-                      <p>
-                        <b>Value: </b>
-                        {Object.getOwnPropertyNames(property.value)[0].toString()}
-                      </p>
-                    </Flex>
-                    <Flex>
-                      <p>
-                        <b>Immutable: </b>
-                        {property.immutable.toString()}
-                      </p>
-                    </Flex>
-                    <Flex justify="flex-end" align="flex-end">
-                      <Button
-                        size="small"
-                        btnType="filled"
-                        onClick={() => removePropertyFromCandyClass(property)}
-                      >
-                        Remove
-                      </Button>
-                    </Flex>
-                  </Flex>
-                ))}
+                  ))
+                }
               </Flex>
             </>
           ) : null}
         </Flex>
       </Container>
-      <Modal
-        closeModal={closeModal}
-        isOpened={openModal}
-        mode="light"
-        size="md"
-      >
+      <Modal closeModal={closeModal} isOpened={openModal} mode="light" size="md">
         <Container padding="16px">
           <Flex flexFlow="column" gap={16}>
             <Flex>
@@ -113,18 +111,19 @@ export const CandyDataEditor = () => {
               />
             </Flex>
             <HR marginTop={8} marginBottom={8} />
-            <Flex>
-              {candyType !== null
-                ? FormTypes[candyType.toString()](candyClassEditor, candyType)
-                : <>
+            <Flex flexFlow="column" gap={16}>
+              {candyType !== null ? (
+                FormTypes[candyType.toString()](addCandyClassEditor)
+              ) : (
+                <>
                   <Flex>Select a Candy Type</Flex>
                   <HR marginTop={8} marginBottom={16} />
-                </>}
+                </>
+              )}
             </Flex>
           </Flex>
         </Container>
       </Modal>
     </Card>
-
   );
 };

--- a/packages/candy_editor/src/assets/index.tsx
+++ b/packages/candy_editor/src/assets/index.tsx
@@ -115,19 +115,23 @@ export const CandyDataEditor = () => {
                         {FormTypes[item.type](
                           createEditCandyClassEditor(item.type, property, index),
                         )}
-                        <Grid column={4}>
-                          <Flex>
-                            <span style={{ marginBottom: 'auto', marginTop: 'auto' }}>
-                              <Button
-                                size="small"
-                                btnType="filled"
-                                onClick={() => removeProperty(index)}
-                              >
-                                Remove
-                              </Button>
-                            </span>
-                          </Flex>
-                        </Grid>
+                        {property.immutable ? (
+                          <></>
+                        ) : (
+                          <Grid column={4}>
+                            <Flex>
+                              <span style={{ marginBottom: 'auto', marginTop: 'auto' }}>
+                                <Button
+                                  size="small"
+                                  btnType="filled"
+                                  onClick={() => removeProperty(index)}
+                                >
+                                  Remove
+                                </Button>
+                              </span>
+                            </Flex>
+                          </Grid>
+                        )}
                       </Grid>
                       <HR marginTop={8} marginBottom={8} />
                     </>

--- a/packages/candy_editor/src/assets/index.tsx
+++ b/packages/candy_editor/src/assets/index.tsx
@@ -14,17 +14,30 @@ export const CandyDataEditor = () => {
 
   const addCandyClassEditor: CandyClassEditor = {
     addPropertyToCandyClass: (property: Property) => {
-      setEditableCandyClass({ Class: [...editableCandyClass.Class, property] });
+      setEditableCandyClass((previous) => {
+        const newClass = [...previous.Class, property];
+        return {
+          ...{
+            Class: newClass,
+          },
+        };
+      });
     },
     candyType: candyType,
     editorMode: editorMode,
   };
 
   const removeProperty = (property: Property, propertyIndex: number): void => {
-    const newClass = editableCandyClass.Class.filter((_, index) => index !== propertyIndex);
-    setEditableCandyClass({ Class: newClass });
+    setEditableCandyClass((previous) => {
+      const firstPart = previous.Class.slice(0, propertyIndex);
+      const secondPart = previous.Class.slice(propertyIndex + 1);
+      return {
+        ...{
+          Class: [...firstPart, ...secondPart],
+        },
+      };
+    });
     console.log('remove', property);
-    console.log('newClass', newClass);
   };
 
   const createEditCandyClassEditor = (
@@ -35,7 +48,7 @@ export const CandyDataEditor = () => {
     return {
       candyType: candyType,
       editorMode: editorMode,
-      editExistingProperty: (updatedProperty: Property) => {
+      editExistingProperty: () => (updatedProperty: Property) => {
         const updated = editableCandyClass.Class.map((property, index) => {
           if (index === propertyIndex) {
             return { ...property, ...updatedProperty };
@@ -74,14 +87,6 @@ export const CandyDataEditor = () => {
     closeModal();
   }, [editableCandyClass]);
 
-  useEffect(() => {
-    console.log('Candy Class', candyClass);
-  }, [candyClass]);
-
-  useEffect(() => {
-    console.log('editableCandy', editableCandyClass);
-  }, [editableCandyClass]);
-
   return (
     <Card type="outlined" padding="16px">
       <Container>
@@ -101,29 +106,32 @@ export const CandyDataEditor = () => {
                 <Grid column={4}>Actions</Grid>
               </Grid>
               <>
-                {editableCandyClass?.Class.map((property, index) => (
-                  <>
-                    <Grid columns={4} gap={16} key={`${property.name}-${property.value}-${index}`}>
-                      {FormTypes[getValueType(property).type](
-                        createEditCandyClassEditor(getValueType(property).type, property, index),
-                      )}
-                      <Grid column={4}>
-                        <Flex>
-                          <span style={{ marginBottom: 'auto', marginTop: 'auto' }}>
-                            <Button
-                              size="small"
-                              btnType="filled"
-                              onClick={() => removeProperty(property, index)}
-                            >
-                              Remove
-                            </Button>
-                          </span>
-                        </Flex>
+                {editableCandyClass.Class.map((property, index) => {
+                  const item = getValueType(property);
+                  return (
+                    <>
+                      <Grid columns={4} gap={16} key={property.name + index}>
+                        {FormTypes[item.type](
+                          createEditCandyClassEditor(item.type, property, index),
+                        )}
+                        <Grid column={4}>
+                          <Flex>
+                            <span style={{ marginBottom: 'auto', marginTop: 'auto' }}>
+                              <Button
+                                size="small"
+                                btnType="filled"
+                                onClick={() => removeProperty(property, index)}
+                              >
+                                Remove
+                              </Button>
+                            </span>
+                          </Flex>
+                        </Grid>
                       </Grid>
-                    </Grid>
-                    <HR marginTop={8} marginBottom={8} />
-                  </>
-                ))}
+                      <HR marginTop={8} marginBottom={8} />
+                    </>
+                  );
+                })}
               </>
               <Flex flexFlow="column" gap={24}>
                 <Flex align="flex-end" justify="flex-end">

--- a/packages/candy_editor/src/assets/index.tsx
+++ b/packages/candy_editor/src/assets/index.tsx
@@ -8,59 +8,65 @@ import { NOT_SELECTED, SELECT_OPTIONS } from '../constants';
 export const CandyDataEditor = () => {
   const [candyType, setCandyType] = useState<CandyType>(NOT_SELECTED);
   const [candyClass, setCandyClass] = useState<CandyClass>({ Class: [] });
+  const [editableCandyClass, setEditableCandyClass] = useState<CandyClass>({ Class: [] });
   const [openModal, setOpenModal] = useState<boolean>(false);
-  const [editorMode, setEditorMode] = useState<EditorMode>("edit");
+  const [editorMode, setEditorMode] = useState<EditorMode>('edit');
 
   const addCandyClassEditor: CandyClassEditor = {
     addPropertyToCandyClass: (property: Property) => {
       setCandyClass({ Class: [...candyClass.Class, property] });
     },
     candyType: candyType,
-    removePropertyFromCandyClass: (property: Property): void => {
-      const newClass = [...candyClass.Class];
-      const index = newClass.indexOf(property);
-      if (index !== -1) {
-        newClass.splice(index, 1);
-      }
-      setCandyClass({ Class: newClass });
-    },
     editorMode: editorMode,
   };
 
-  const createEditCandyClassEditor = (candyType: string, property: Property, propIndex: number): CandyClassEditor => {
+  const createEditCandyClassEditor = (
+    candyType: string,
+    property: Property,
+    propertyIndex: number,
+  ): CandyClassEditor => {
     return {
       candyType: candyType,
       editorMode: editorMode,
-      editExistingProperty: (updatedProperty: Property,) => {
-        const updatedProperties = candyClass.Class.map((property, index) => {
-          if (index === propIndex) {
+      editExistingProperty: (updatedProperty: Property) => {
+        const updated = candyClass.Class.map((property, index) => {
+          if (index === propertyIndex) {
             return { ...property, ...updatedProperty };
           }
           return property;
         });
-        setCandyClass({ Class: updatedProperties });
+        setEditableCandyClass({ Class: updated });
       },
-      property: property
-    }
-  }
-
-  const displayModal = () => {
-    setOpenModal(true);
-    setEditorMode("create")
+      removePropertyFromCandyClass: (property: Property): void => {
+        const updated = candyClass.Class.filter((item) => item !== property);
+        setCandyClass({ Class: updated });
+      },
+      property: property,
+    };
   };
 
-  const closeModal = () => {
+  const displayModal = (): void => {
+    setOpenModal(true);
+    setEditorMode('create');
+  };
+
+  const closeModal = (): void => {
     setOpenModal(false);
     setCandyType(NOT_SELECTED);
-    setEditorMode("edit")
+    setEditorMode('edit');
   };
 
-  const handleSelectChange = (candySelectedType: CandyClass) => {
+  const handleSelectChange = (candySelectedType: CandyClass): void => {
     setCandyType(candySelectedType);
+  };
+
+  const saveCandyClass = (): void => {
+    setCandyClass({ Class: [...editableCandyClass.Class] });
   };
 
   useEffect(() => {
     console.log('Candy Class', candyClass);
+    setEditableCandyClass(candyClass);
     setCandyType(NOT_SELECTED);
     closeModal();
   }, [candyClass]);
@@ -78,24 +84,29 @@ export const CandyDataEditor = () => {
             <>
               <HR marginTop={8} marginBottom={8} />
               <Flex flexFlow="column" gap={24}>
-                {
-                  candyClass.Class.map((property, index) => (
-                    <Flex flexFlow="row" gap={24} key={index}>
-                      {
-                        FormTypes[getValueType(property).type](
-                          createEditCandyClassEditor(getValueType(property).type, property, index)
-                        )
-                      }
-                    </Flex>
-                  ))
-                }
+                {candyClass.Class.map((property, index) => (
+                  <Flex flexFlow="row" gap={24} key={index}>
+                    {FormTypes[getValueType(property).type](
+                      createEditCandyClassEditor(getValueType(property).type, property, index),
+                    )}
+                  </Flex>
+                ))}
+                <Flex align="flex-end" justify="flex-end">
+                  {editableCandyClass === candyClass ? null : (
+                    <>
+                      <Button size="medium" btnType="filled" onClick={saveCandyClass}>
+                        Save Candy Class
+                      </Button>
+                    </>
+                  )}
+                </Flex>
               </Flex>
             </>
           ) : null}
         </Flex>
       </Container>
       <Modal closeModal={closeModal} isOpened={openModal} mode="light" size="md">
-        <Container padding="16px">
+        <Container size="full" padding="48px">
           <Flex flexFlow="column" gap={16}>
             <Flex>
               <Select
@@ -110,14 +121,12 @@ export const CandyDataEditor = () => {
                 }))}
               />
             </Flex>
-            <HR marginTop={8} marginBottom={8} />
             <Flex flexFlow="column" gap={16}>
               {candyType !== null ? (
                 FormTypes[candyType.toString()](addCandyClassEditor)
               ) : (
                 <>
                   <Flex>Select a Candy Type</Flex>
-                  <HR marginTop={8} marginBottom={16} />
                 </>
               )}
             </Flex>

--- a/packages/candy_editor/src/assets/index.tsx
+++ b/packages/candy_editor/src/assets/index.tsx
@@ -3,14 +3,14 @@ import { Card, Flex, Grid, Button, HR, Select, Container, Modal } from '@origyn-
 import { FormTypes } from './formTypes';
 import type { Property, CandyClassEditor, CandyClass, CandyType, EditorMode } from '../types';
 import { getValueType } from '../utils/functions';
-import { NOT_SELECTED, SELECT_OPTIONS } from '../constants';
+import { NOT_SELECTED, SELECT_OPTIONS, CREATE_MODE, EDIT_MODE } from '../constants';
 
 export const CandyDataEditor = () => {
   const [candyType, setCandyType] = useState<CandyType>(NOT_SELECTED);
   const [candyClass, setCandyClass] = useState<CandyClass>({ Class: [] });
   const [editableCandyClass, setEditableCandyClass] = useState<CandyClass>({ Class: [] });
   const [openModal, setOpenModal] = useState<boolean>(false);
-  const [editorMode, setEditorMode] = useState<EditorMode>('edit');
+  const [editorMode, setEditorMode] = useState<EditorMode>(EDIT_MODE);
 
   const addCandyClassEditor: CandyClassEditor = {
     addPropertyToCandyClass: (property: Property) => {
@@ -27,7 +27,7 @@ export const CandyDataEditor = () => {
     editorMode: editorMode,
   };
 
-  const removeProperty = (property: Property, propertyIndex: number): void => {
+  const removeProperty = (propertyIndex: number): void => {
     setEditableCandyClass((previous) => {
       const firstPart = previous.Class.slice(0, propertyIndex);
       const secondPart = previous.Class.slice(propertyIndex + 1);
@@ -37,7 +37,6 @@ export const CandyDataEditor = () => {
         },
       };
     });
-    console.log('remove', property);
   };
 
   const createEditCandyClassEditor = (
@@ -63,13 +62,13 @@ export const CandyDataEditor = () => {
 
   const displayModal = (): void => {
     setOpenModal(true);
-    setEditorMode('create');
+    setEditorMode(CREATE_MODE);
   };
 
   const closeModal = (): void => {
     setOpenModal(false);
     setCandyType(NOT_SELECTED);
-    setEditorMode('edit');
+    setEditorMode(EDIT_MODE);
   };
 
   const handleSelectChange = (candySelectedType: CandyClass): void => {
@@ -77,8 +76,6 @@ export const CandyDataEditor = () => {
   };
 
   const saveCandyClass = (): void => {
-    console.log('e', editableCandyClass);
-    console.log('c', candyClass);
     setCandyClass(editableCandyClass);
   };
 
@@ -86,6 +83,10 @@ export const CandyDataEditor = () => {
     setCandyType(NOT_SELECTED);
     closeModal();
   }, [editableCandyClass]);
+
+  useEffect(() => {
+    console.log('CANDYCLASS', candyClass)
+  }, [candyClass]);
 
   return (
     <Card type="outlined" padding="16px">
@@ -120,7 +121,7 @@ export const CandyDataEditor = () => {
                               <Button
                                 size="small"
                                 btnType="filled"
-                                onClick={() => removeProperty(property, index)}
+                                onClick={() => removeProperty(index)}
                               >
                                 Remove
                               </Button>

--- a/packages/candy_editor/src/assets/index.tsx
+++ b/packages/candy_editor/src/assets/index.tsx
@@ -38,6 +38,15 @@ export const CandyDataEditor = () => {
       };
     });
   };
+  const editExistingProperty = (updatedProperty: Property, propertyIndex: number) => {
+    const updated = editableCandyClass.Class.map((property, index) => {
+      if (index === propertyIndex) {
+        return { ...property, ...updatedProperty };
+      }
+      return property;
+    });
+    setEditableCandyClass({ Class: updated });
+  }
 
   const createEditCandyClassEditor = (
     candyType: string,
@@ -45,18 +54,10 @@ export const CandyDataEditor = () => {
     propertyIndex: number,
   ): CandyClassEditor => {
     return {
-      candyType: candyType,
-      editorMode: editorMode,
-      editExistingProperty: () => (updatedProperty: Property) => {
-        const updated = editableCandyClass.Class.map((property, index) => {
-          if (index === propertyIndex) {
-            return { ...property, ...updatedProperty };
-          }
-          return property;
-        });
-        setEditableCandyClass({ Class: updated });
-      },
-      property: property,
+      candyType,
+      editorMode,
+      editExistingProperty: () => editExistingProperty(property, propertyIndex),
+      property,
     };
   };
 

--- a/packages/candy_editor/src/assets/index.tsx
+++ b/packages/candy_editor/src/assets/index.tsx
@@ -1,13 +1,22 @@
 import React, { useEffect, useState } from 'react';
-import { Card, Flex, Button, HR, Select, Container } from '@origyn-sa/origyn-art-ui';
+import { Card, Flex, Button, HR, Select, Container, Modal } from '@origyn-sa/origyn-art-ui';
 import { FormTypes } from './formTypes';
 import type { Property, CandyClassEditor, CandyClass, CandyType } from '../types';
 import { NOT_SELECTED, SELECT_OPTIONS } from '../constants';
 
 export const CandyDataEditor = () => {
-  const [openForm, setOpenForm] = React.useState(false);
   const [candyType, setCandyType] = useState<CandyType>(NOT_SELECTED);
   const [candyClass, setCandyClass] = useState<CandyClass>({ Class: [] });
+  const [openModal, setOpenModal] = useState<boolean>(false);
+
+  const removePropertyFromCandyClass = (property: Property): void => {
+    const newClass = [...candyClass.Class];
+    const index = newClass.indexOf(property);
+    if (index !== -1) {
+      newClass.splice(index, 1);
+    }
+    setCandyClass({ Class: newClass });
+  };
 
   const candyClassEditor: CandyClassEditor = {
     addPropertyToCandyClass: (property: Property) => {
@@ -16,8 +25,12 @@ export const CandyDataEditor = () => {
     candyType: candyType,
   };
 
-  const handleOpenForm = () => {
-    setOpenForm(!openForm);
+  const displayModal = () => {
+    setOpenModal(true);
+  };
+
+  const closeModal = () => {
+    setOpenModal(false);
   };
 
   const handleSelectChange = (candySelectedType: CandyClass) => {
@@ -34,51 +47,84 @@ export const CandyDataEditor = () => {
       <Container>
         <Flex flexFlow="column" gap={16}>
           <Flex>
-            <Button size="small" btnType="filled" onClick={handleOpenForm}>
+            <Button size="small" btnType="filled" onClick={displayModal}>
               + Add Candy Value
             </Button>
           </Flex>
-          {openForm ? (
-            <>
-              <HR marginTop={8} marginBottom={8} />
-              <Flex flexFlow="column" gap={16}>
-                <Flex>
-                  <Select
-                    inputSize="medium"
-                    label="Select Candy Type"
-                    handleChange={(type) => {
-                      handleSelectChange(type.value);
-                    }}
-                    options={SELECT_OPTIONS.map((option) => ({
-                      label: option.label,
-                      value: option.value,
-                    }))}
-                  />
-                </Flex>
-                <HR marginTop={8} marginBottom={8} />
-                <Flex>
-                  {candyType !== null ? FormTypes[candyType.toString()](candyClassEditor, candyType) : null}
-                </Flex>
-              </Flex>
-            </>
-          ) : null}
           {candyClass.Class.length > 0 ? (
             <>
               <HR marginTop={8} marginBottom={8} />
-              <Flex>
-                <b>Your Candy Class: </b>{' '}
-                <pre>
-                  {JSON.stringify(
-                    candyClass,
-                    (this, (key, value) => (typeof value === 'bigint' ? value.toString() : value)),
-                    2,
-                  )}
-                </pre>
+              <Flex flexFlow="column" gap={16}>
+                {candyClass.Class.map((property, index) => (
+                  <Flex key={index} flexFlow="row" gap={8}>
+                    <Flex>
+                      <p>
+                        <b>Name: </b>
+                        {property.name}
+                      </p>
+                    </Flex>
+                    <Flex>
+                      <p>
+                        <b>Value: </b>
+                        {Object.getOwnPropertyNames(property.value)[0].toString()}
+                      </p>
+                    </Flex>
+                    <Flex>
+                      <p>
+                        <b>Immutable: </b>
+                        {property.immutable.toString()}
+                      </p>
+                    </Flex>
+                    <Flex justify="flex-end" align="flex-end">
+                      <Button
+                        size="small"
+                        btnType="filled"
+                        onClick={() => removePropertyFromCandyClass(property)}
+                      >
+                        Remove
+                      </Button>
+                    </Flex>
+                  </Flex>
+                ))}
               </Flex>
             </>
           ) : null}
         </Flex>
       </Container>
+      <Modal
+        closeModal={closeModal}
+        isOpened={openModal}
+        mode="light"
+        size="md"
+      >
+        <Container padding="16px">
+          <Flex flexFlow="column" gap={16}>
+            <Flex>
+              <Select
+                inputSize="medium"
+                label="Select Candy Type"
+                handleChange={(type) => {
+                  handleSelectChange(type.value);
+                }}
+                options={SELECT_OPTIONS.map((option) => ({
+                  label: option.label,
+                  value: option.value,
+                }))}
+              />
+            </Flex>
+            <HR marginTop={8} marginBottom={8} />
+            <Flex>
+              {candyType !== null
+                ? FormTypes[candyType.toString()](candyClassEditor, candyType)
+                : <>
+                  <Flex>Select a Candy Type</Flex>
+                  <HR marginTop={8} marginBottom={16} />
+                </>}
+            </Flex>
+          </Flex>
+        </Container>
+      </Modal>
     </Card>
+
   );
 };

--- a/packages/candy_editor/src/assets/index.tsx
+++ b/packages/candy_editor/src/assets/index.tsx
@@ -36,15 +36,16 @@ export const CandyDataEditor = () => {
           return property;
         });
         setEditableCandyClass({ Class: updated });
-        setCandyClass({ Class: updated });
       },
       removePropertyFromCandyClass: (property: Property): void => {
-        const updated = candyClass.Class.filter((item, index) => index !== propertyIndex);
-        alert(propertyIndex);
-        setEditableCandyClass({ Class: updated });
-        console.log('editableCandyClass', editableCandyClass);
-        setCandyClass({ Class: updated });
-        console.log('candyClass', candyClass)
+        const newClass = candyClass.Class;
+        const index = newClass.indexOf(property);
+        if (index !== -1) {
+          newClass.splice(index, 1);
+        }
+
+        console.log('New Class', newClass);
+        setEditableCandyClass({ Class: newClass });
       },
       property: property,
     };
@@ -66,7 +67,7 @@ export const CandyDataEditor = () => {
   };
 
   const saveCandyClass = (): void => {
-    setCandyClass({ Class: [...editableCandyClass.Class] });
+    setCandyClass(editableCandyClass);
   };
 
   useEffect(() => {

--- a/packages/candy_editor/src/assets/index.tsx
+++ b/packages/candy_editor/src/assets/index.tsx
@@ -14,10 +14,17 @@ export const CandyDataEditor = () => {
 
   const addCandyClassEditor: CandyClassEditor = {
     addPropertyToCandyClass: (property: Property) => {
-      setCandyClass({ Class: [...candyClass.Class, property] });
+      setEditableCandyClass({ Class: [...editableCandyClass.Class, property] });
     },
     candyType: candyType,
     editorMode: editorMode,
+  };
+
+  const removeProperty = (property: Property, propertyIndex: number): void => {
+    const newClass = editableCandyClass.Class.filter((_, index) => index !== propertyIndex);
+    setEditableCandyClass({ Class: newClass });
+    console.log('remove', property);
+    console.log('newClass', newClass);
   };
 
   const createEditCandyClassEditor = (
@@ -29,23 +36,13 @@ export const CandyDataEditor = () => {
       candyType: candyType,
       editorMode: editorMode,
       editExistingProperty: (updatedProperty: Property) => {
-        const updated = candyClass.Class.map((property, index) => {
+        const updated = editableCandyClass.Class.map((property, index) => {
           if (index === propertyIndex) {
             return { ...property, ...updatedProperty };
           }
           return property;
         });
         setEditableCandyClass({ Class: updated });
-      },
-      removePropertyFromCandyClass: (property: Property): void => {
-        const newClass = candyClass.Class;
-        const index = newClass.indexOf(property);
-        if (index !== -1) {
-          newClass.splice(index, 1);
-        }
-
-        console.log('New Class', newClass);
-        setEditableCandyClass({ Class: newClass });
       },
       property: property,
     };
@@ -67,15 +64,23 @@ export const CandyDataEditor = () => {
   };
 
   const saveCandyClass = (): void => {
+    console.log('e', editableCandyClass);
+    console.log('c', candyClass);
     setCandyClass(editableCandyClass);
   };
 
   useEffect(() => {
-    console.log('Candy Class', candyClass);
-    setEditableCandyClass(candyClass);
     setCandyType(NOT_SELECTED);
     closeModal();
+  }, [editableCandyClass]);
+
+  useEffect(() => {
+    console.log('Candy Class', candyClass);
   }, [candyClass]);
+
+  useEffect(() => {
+    console.log('editableCandy', editableCandyClass);
+  }, [editableCandyClass]);
 
   return (
     <Card type="outlined" padding="16px">
@@ -86,22 +91,35 @@ export const CandyDataEditor = () => {
               + Add Candy Value
             </Button>
           </Flex>
-          {candyClass.Class.length > 0 ? (
+          {editableCandyClass.Class.length > 0 ? (
             <>
               <HR marginTop={8} marginBottom={8} />
               <Grid columns={4} gap={16}>
-                <Flex>Property Name</Flex>
-                <Flex>Property Value</Flex>
-                <Flex>Immutable</Flex>
-                <Flex>Actions</Flex>
+                <Grid column={1}>Property Name</Grid>
+                <Grid column={2}>Property Value</Grid>
+                <Grid column={3}>Immutable</Grid>
+                <Grid column={4}>Actions</Grid>
               </Grid>
               <>
-                {candyClass.Class.map((property, index) => (
+                {editableCandyClass?.Class.map((property, index) => (
                   <>
-                    <Grid columns={4} gap={16}>
+                    <Grid columns={4} gap={16} key={`${property.name}-${property.value}-${index}`}>
                       {FormTypes[getValueType(property).type](
                         createEditCandyClassEditor(getValueType(property).type, property, index),
                       )}
+                      <Grid column={4}>
+                        <Flex>
+                          <span style={{ marginBottom: 'auto', marginTop: 'auto' }}>
+                            <Button
+                              size="small"
+                              btnType="filled"
+                              onClick={() => removeProperty(property, index)}
+                            >
+                              Remove
+                            </Button>
+                          </span>
+                        </Flex>
+                      </Grid>
                     </Grid>
                     <HR marginTop={8} marginBottom={8} />
                   </>
@@ -111,7 +129,7 @@ export const CandyDataEditor = () => {
                 <Flex align="flex-end" justify="flex-end">
                   {editableCandyClass === candyClass ? null : (
                     <>
-                      <Button size="medium" btnType="filled" onClick={saveCandyClass}>
+                      <Button size="medium" btnType="filled" onClick={() => saveCandyClass()}>
                         Save Candy Class
                       </Button>
                     </>

--- a/packages/candy_editor/src/constants.ts
+++ b/packages/candy_editor/src/constants.ts
@@ -1,4 +1,8 @@
+import { EditorMode } from "./types";
+
 export const NOT_SELECTED: string = null;
+export const CREATE_MODE: EditorMode = 'create';
+export const EDIT_MODE: EditorMode = 'edit';
 
 export const SELECT_OPTIONS: Array<{ label: string; value: string }> = [
   { label: 'Text', value: 'Text' },

--- a/packages/candy_editor/src/constants.ts
+++ b/packages/candy_editor/src/constants.ts
@@ -7,7 +7,6 @@ export const SELECT_OPTIONS: Array<{ label: string; value: string }> = [
   { label: 'Nat16', value: 'Nat16' },
   { label: 'Nat32', value: 'Nat32' },
   { label: 'Nat64', value: 'Nat64' },
-  { label: 'Nats', value: 'Nats' },
   { label: 'Int', value: 'Int' },
   { label: 'Int8', value: 'Int8' },
   { label: 'Int16', value: 'Int16' },

--- a/packages/candy_editor/src/tests/converters.test.js
+++ b/packages/candy_editor/src/tests/converters.test.js
@@ -1,5 +1,4 @@
 import {
-  isInRange,
   convertToCandyNat,
   convertToCandyNat8,
   convertToCandyNat16,
@@ -16,9 +15,10 @@ import {
 import { convertToCandyBool } from '../assets/formTypes/BoolForm/converters';
 import { convertToCandyFloat } from '../assets/formTypes/FloatForm/converters';
 import { convertToCandyPrincipal } from '../assets/formTypes/PrincipalForm/converters';
+import { isInRange } from '../utils/functions';
 import { Principal } from '@dfinity/principal';
 
-describe('NatForms > converters.ts', () => {
+describe('Utils > functions.ts', () => {
   it('isInRange > returns true for numbers within the range', () => {
     expect(isInRange(10, 0, 30)).toBe(true);
     expect(isInRange(5, 5, 5)).toBe(true);
@@ -28,7 +28,9 @@ describe('NatForms > converters.ts', () => {
     expect(isInRange(0, 4, 9)).toBe(false);
     expect(isInRange(3, 9, 10)).toBe(false);
   });
+});
 
+describe('NatForms > converters.ts', () => {
   it('convertToCandyNat > returns a CandyNat object for valid natural number strings', () => {
     expect(convertToCandyNat('152661')).toEqual({ Nat: BigInt(152661) });
     expect(convertToCandyNat('1')).toEqual({ Nat: BigInt(1) });

--- a/packages/candy_editor/src/types/index.ts
+++ b/packages/candy_editor/src/types/index.ts
@@ -8,7 +8,7 @@ export interface Property {
   immutable: boolean;
 }
 
-export interface PropertyType extends Property {
+export interface PropertyWithType extends Property {
   type: string;
 }
 

--- a/packages/candy_editor/src/types/index.ts
+++ b/packages/candy_editor/src/types/index.ts
@@ -88,7 +88,7 @@ export type EditorMode = "create" | "edit" | null;
 export interface CandyClassEditor {
   addPropertyToCandyClass?: (property: Property) => void;
   candyType?: CandyType;
-  editExistingProperty?: (updatedProperty: Property) => void;
+  editExistingProperty?: (updatedProperty: Property, propertyIndex: number) => void;
   property?: Property;
   editorMode: EditorMode;
 }

--- a/packages/candy_editor/src/types/index.ts
+++ b/packages/candy_editor/src/types/index.ts
@@ -8,6 +8,10 @@ export interface Property {
   immutable: boolean;
 }
 
+export interface PropertyType extends Property {
+  type: string;
+}
+
 export interface CandyIntegers extends CandyType { }
 
 export interface CandyNaturals extends CandyType { }
@@ -79,7 +83,13 @@ export interface CandyArray extends CandyType {
   Array: { thawed: Array<CandyType> } | { frozen: Array<CandyType> };
 }
 
+export type EditorMode = "create" | "edit" | null;
+
 export interface CandyClassEditor {
-  addPropertyToCandyClass: (property: Property) => void;
-  candyType: CandyType;
+  addPropertyToCandyClass?: (property: Property) => void;
+  candyType?: CandyType;
+  editExistingProperty?: (updatedProperty: Property) => void;
+  property?: Property;
+  removePropertyFromCandyClass?: (property: Property) => void;
+  editorMode: EditorMode;
 }

--- a/packages/candy_editor/src/types/index.ts
+++ b/packages/candy_editor/src/types/index.ts
@@ -12,6 +12,10 @@ export interface PropertyWithType extends Property {
   type: string;
 }
 
+export interface PropertyWithId extends Property {
+  id: string;
+}
+
 export interface CandyIntegers extends CandyType { }
 
 export interface CandyNaturals extends CandyType { }
@@ -22,6 +26,11 @@ export interface CandyEmpty extends CandyType {
 export interface CandyClass extends CandyType {
   Class: Array<Property>;
 }
+
+export interface EditableCandyClass {
+  Class: Array<PropertyWithId>;
+}
+
 export interface CandyText extends CandyType {
   Text: string;
 }
@@ -86,9 +95,10 @@ export interface CandyArray extends CandyType {
 export type EditorMode = "create" | "edit" | null;
 
 export interface CandyClassEditor {
-  addPropertyToCandyClass?: (property: Property) => void;
+  addPropertyToCandyClass?: (property: PropertyWithId) => void;
   candyType?: CandyType;
   editExistingProperty?: (updatedProperty: Property, propertyIndex: number) => void;
-  property?: Property;
   editorMode: EditorMode;
+  property?: Property;
+  propertyIndex?: number;
 }

--- a/packages/candy_editor/src/types/index.ts
+++ b/packages/candy_editor/src/types/index.ts
@@ -90,6 +90,5 @@ export interface CandyClassEditor {
   candyType?: CandyType;
   editExistingProperty?: (updatedProperty: Property) => void;
   property?: Property;
-  removePropertyFromCandyClass?: (property: Property) => void;
   editorMode: EditorMode;
 }

--- a/packages/candy_editor/src/utils/functions.ts
+++ b/packages/candy_editor/src/utils/functions.ts
@@ -1,4 +1,4 @@
-import { PropertyType, Property } from '../types'
+import { PropertyWithType, Property } from '../types'
 
 export function isInRange(
   num: number | bigint,
@@ -8,10 +8,10 @@ export function isInRange(
   return num >= min && num <= max;
 }
 
-export function getValueType(property: Property): PropertyType {
-  let propertyType: PropertyType;
+export function getValueType(property: Property): PropertyWithType {
+  let propertyWithType: PropertyWithType;
   const valueType: string = Object.getOwnPropertyNames(property.value)[0];
-  return propertyType = {
+  return propertyWithType = {
     type: valueType,
     name: property.name,
     immutable: property.immutable,

--- a/packages/candy_editor/src/utils/functions.ts
+++ b/packages/candy_editor/src/utils/functions.ts
@@ -1,0 +1,20 @@
+import { PropertyType, Property } from '../types'
+
+export function isInRange(
+  num: number | bigint,
+  min: number | bigint,
+  max: number | bigint,
+): boolean {
+  return num >= min && num <= max;
+}
+
+export function getValueType(property: Property): PropertyType {
+  let propertyType: PropertyType;
+  const valueType: string = Object.getOwnPropertyNames(property.value)[0];
+  return propertyType = {
+    type: valueType,
+    name: property.name,
+    immutable: property.immutable,
+    value: property.value
+  };
+}


### PR DESCRIPTION
**ENG-1140 : Remove Candy - EditableForm View**

###  types > index.ts
- added interfaces  EditableCandyClass, PropertyWithId, PropertyWithType
- updated interface CandyClass editor with propertyIndex, editorMode, editExistingProperty

### assets > index.tsx
- function RemoveProperty : removes a property from the editableCandyClass: EditableCandyClass
- function editExistingProperty : edits a property: PropertyWithId in the EditableCandyClass: EditableCandyClass
- function createEditCandyClassEditor : returns a CandyClassEditor - used for the editable form view
- function saveCandyClass : it takes the properties from EditableCandyClass and saves them in the CandyClass. Every property: PropertyWithId is pushed in the CandyClass as Property: Property.

### formTypes
- updated all the formTypes in order to be able to edit the EditableCandyClass in the editable form view with validations.

