### PR TITLE
ENG-1461 Disable start auction button

### DIFF
--- a/packages/features/sales-escrows/modals/ConfirmSalesActionModal.tsx
+++ b/packages/features/sales-escrows/modals/ConfirmSalesActionModal.tsx
@@ -23,7 +23,7 @@ Transition.displayName = 'Transition';
 
 interface ConfirmSalesActionModalProps {
   openConfirmation: boolean;
-  handleClose: (confirm: boolean) => void;
+  onClose: (confirm: boolean) => void;
   currentToken: string;
   action: string;
   escrow?: EscrowRecord;
@@ -34,7 +34,7 @@ interface ConfirmSalesActionModalProps {
 
 export const ConfirmSalesActionModal = ({
   openConfirmation,
-  handleClose,
+  onClose,
   currentToken,
   action,
   escrow = null,
@@ -50,8 +50,11 @@ export const ConfirmSalesActionModal = ({
   const debug = useDebug();
 
   const _handleClose = async (confirm = false) => {
-    if (!confirm || !actor || isLoading) return;
-
+    if (!confirm) {
+      onClose(false);
+    } else if (isLoading || !actor) {
+      return;
+    }
     try {
       setIsLoading(true);
       setConfirmed(true);
@@ -80,7 +83,7 @@ export const ConfirmSalesActionModal = ({
       }
       if (action === 'withdraw') {
         if (!escrow) {
-          return handleClose(false);
+          return onClose(false);
         }
         const withdrawResponse = await actor?.sale_nft_origyn({
           withdraw: {
@@ -112,7 +115,7 @@ export const ConfirmSalesActionModal = ({
 
       if (action === 'reject') {
         if (!escrow) {
-          return handleClose(false);
+          return onClose(false);
         }
         const rejectResponse = await actor?.sale_nft_origyn({
           withdraw: {
@@ -191,13 +194,12 @@ export const ConfirmSalesActionModal = ({
           debug.log(e);
         }
       }
-      handleClose(false);
     } catch (e) {
       debug.log(e);
     } finally {
       setInProcess?.(false);
       setIsLoading(false);
-      handleClose(false);
+      onClose(false);
     }
   };
 
@@ -206,7 +208,7 @@ export const ConfirmSalesActionModal = ({
   }, [openConfirmation]);
 
   return (
-    <Modal isOpened={openConfirmation} closeModal={() => handleClose(false)} size="md">
+    <Modal isOpened={openConfirmation} closeModal={() => onClose(false)} size="md">
       <Container size="full" padding="48px">
         <h2>
           {action === 'acceptOffer'

--- a/packages/features/sales-escrows/modals/ConfirmSalesActionModal.tsx
+++ b/packages/features/sales-escrows/modals/ConfirmSalesActionModal.tsx
@@ -29,7 +29,7 @@ interface ConfirmSalesActionModalProps {
   escrow?: EscrowRecord;
   offer?: EscrowRecord;
   onSaleCancelled?: () => void;
-  setInProcess?: (any) => void;
+  setInProcess?: (boolean) => void;
 }
 
 export const ConfirmSalesActionModal = ({

--- a/packages/features/sales-escrows/modals/ConfirmSalesActionModal.tsx
+++ b/packages/features/sales-escrows/modals/ConfirmSalesActionModal.tsx
@@ -23,13 +23,13 @@ Transition.displayName = 'Transition';
 
 interface ConfirmSalesActionModalProps {
   openConfirmation: boolean;
-  onClose: (confirm: boolean) => void;
+  onClose: () => void;
   currentToken: string;
   action: string;
   escrow?: EscrowRecord;
   offer?: EscrowRecord;
   onSaleCancelled?: () => void;
-  setInProcess?: (boolean) => void;
+  onProcessing?: (boolean) => void;
 }
 
 export const ConfirmSalesActionModal = ({
@@ -40,7 +40,7 @@ export const ConfirmSalesActionModal = ({
   escrow = null,
   offer,
   onSaleCancelled,
-  setInProcess,
+  onProcessing,
 }: ConfirmSalesActionModalProps) => {
   const { actor, principal } = React.useContext(AuthContext);
   const [isLoading, setIsLoading] = React.useState(false);
@@ -51,14 +51,14 @@ export const ConfirmSalesActionModal = ({
 
   const _handleClose = async (confirm = false) => {
     if (!confirm) {
-      onClose(false);
+      onClose();
     } else if (isLoading || !actor) {
       return;
     }
     try {
       setIsLoading(true);
       setConfirmed(true);
-      setInProcess?.(true);
+      onProcessing?.(true);
       if (action === 'endSale') {
         const endSaleResponse = await actor.sale_nft_origyn({
           end_sale: currentToken,
@@ -83,7 +83,7 @@ export const ConfirmSalesActionModal = ({
       }
       if (action === 'withdraw') {
         if (!escrow) {
-          return onClose(false);
+          return onClose();
         }
         const withdrawResponse = await actor?.sale_nft_origyn({
           withdraw: {
@@ -115,7 +115,7 @@ export const ConfirmSalesActionModal = ({
 
       if (action === 'reject') {
         if (!escrow) {
-          return onClose(false);
+          return onClose();
         }
         const rejectResponse = await actor?.sale_nft_origyn({
           withdraw: {
@@ -197,9 +197,9 @@ export const ConfirmSalesActionModal = ({
     } catch (e) {
       debug.log(e);
     } finally {
-      setInProcess?.(false);
+      onProcessing?.(false);
       setIsLoading(false);
-      onClose(false);
+      onClose();
     }
   };
 
@@ -208,7 +208,7 @@ export const ConfirmSalesActionModal = ({
   }, [openConfirmation]);
 
   return (
-    <Modal isOpened={openConfirmation} closeModal={() => onClose(false)} size="md">
+    <Modal isOpened={openConfirmation} closeModal={() => onClose()} size="md">
       <Container size="full" padding="48px">
         <h2>
           {action === 'acceptOffer'

--- a/packages/features/sales-escrows/modals/ConfirmSalesActionModal.tsx
+++ b/packages/features/sales-escrows/modals/ConfirmSalesActionModal.tsx
@@ -54,7 +54,7 @@ export const ConfirmSalesActionModal = ({
       if (isLoading) return;
       setIsLoading(true);
       setConfirmed(true);
-      setInProcess(true);
+      setInProcess?.(true);
       if (action === 'endSale') {
         const endSaleResponse = await actor.sale_nft_origyn({
           end_sale: currentToken,
@@ -67,7 +67,7 @@ export const ConfirmSalesActionModal = ({
               horizontal: 'right',
             },
           });
-          setInProcess(false);
+          setInProcess?.(false);
           onSaleCancelled();
           setIsLoading(false);
           return handleClose(true);
@@ -79,7 +79,7 @@ export const ConfirmSalesActionModal = ({
             horizontal: 'right',
           },
         });
-        setInProcess(false);
+        setInProcess?.(false);
         setIsLoading(false);
         return handleClose(false);
       }
@@ -112,11 +112,11 @@ export const ConfirmSalesActionModal = ({
               horizontal: 'right',
             },
           });
-          setInProcess(false);
+          setInProcess?.(false);
           setIsLoading(false);
           return handleClose(true);
         }
-        setInProcess(false);
+        setInProcess?.(false);
         setIsLoading(false);
         return handleClose(false);
       }
@@ -149,11 +149,11 @@ export const ConfirmSalesActionModal = ({
               horizontal: 'right',
             },
           });
-          setInProcess(false);
+          setInProcess?.(false);
           setIsLoading(false);
           return handleClose(true);
         }
-        setInProcess(false);
+        setInProcess?.(false);
         setIsLoading(false);
         return handleClose(false);
       }
@@ -206,7 +206,7 @@ export const ConfirmSalesActionModal = ({
             setIsLoading(false);
             return handleClose(true);
           }
-          setInProcess(false);
+          setInProcess?.(false);
           setIsLoading(false);
           return handleClose(false);
         } catch (e) {

--- a/packages/features/sales-escrows/modals/ConfirmSalesActionModal.tsx
+++ b/packages/features/sales-escrows/modals/ConfirmSalesActionModal.tsx
@@ -8,6 +8,7 @@ import { Container, Flex, Modal, Button } from '@origyn-sa/origyn-art-ui';
 import { useTokensContext } from '@dapp/features-tokens-provider';
 import { Principal } from '@dfinity/principal';
 import { EscrowReceipt, EscrowRecord } from '@dapp/common-types';
+import { useDebug } from '@dapp/features-debug-provider';
 
 const Transition = React.forwardRef(
   (
@@ -28,6 +29,7 @@ interface ConfirmSalesActionModalProps {
   escrow?: EscrowRecord;
   offer?: EscrowRecord;
   onSaleCancelled?: () => void;
+  setInProcess?: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export const ConfirmSalesActionModal = ({
@@ -38,18 +40,21 @@ export const ConfirmSalesActionModal = ({
   escrow = null,
   offer,
   onSaleCancelled,
+  setInProcess,
 }: ConfirmSalesActionModalProps) => {
   const { actor, principal } = React.useContext(AuthContext);
   const [isLoading, setIsLoading] = React.useState(false);
   const { enqueueSnackbar } = useSnackbar() || {};
   const { tokens } = useTokensContext();
   const [confirmed, setConfirmed] = useState(false);
+  const debug = useDebug();
 
   const _handleClose = async (confirm = false) => {
     if (confirm && actor) {
       if (isLoading) return;
       setIsLoading(true);
       setConfirmed(true);
+      setInProcess(true);
       if (action === 'endSale') {
         const endSaleResponse = await actor.sale_nft_origyn({
           end_sale: currentToken,
@@ -62,6 +67,7 @@ export const ConfirmSalesActionModal = ({
               horizontal: 'right',
             },
           });
+          setInProcess(false);
           onSaleCancelled();
           setIsLoading(false);
           return handleClose(true);
@@ -73,6 +79,7 @@ export const ConfirmSalesActionModal = ({
             horizontal: 'right',
           },
         });
+        setInProcess(false);
         setIsLoading(false);
         return handleClose(false);
       }
@@ -105,10 +112,11 @@ export const ConfirmSalesActionModal = ({
               horizontal: 'right',
             },
           });
+          setInProcess(false);
           setIsLoading(false);
           return handleClose(true);
         }
-
+        setInProcess(false);
         setIsLoading(false);
         return handleClose(false);
       }
@@ -141,9 +149,11 @@ export const ConfirmSalesActionModal = ({
               horizontal: 'right',
             },
           });
+          setInProcess(false);
           setIsLoading(false);
           return handleClose(true);
         }
+        setInProcess(false);
         setIsLoading(false);
         return handleClose(false);
       }
@@ -176,7 +186,7 @@ export const ConfirmSalesActionModal = ({
             token_id: currentToken,
             sales_config: saleReceipt,
           });
-          console.log(acceptOffer.err);
+          debug.log(acceptOffer.err);
           if ('err' in acceptOffer) {
             enqueueSnackbar('There has been an error in accepting the offer', {
               variant: 'error',
@@ -196,10 +206,11 @@ export const ConfirmSalesActionModal = ({
             setIsLoading(false);
             return handleClose(true);
           }
+          setInProcess(false);
           setIsLoading(false);
           return handleClose(false);
         } catch (e) {
-          console.log(e);
+          debug.log(e);
         }
       }
     }

--- a/packages/features/sales-escrows/modals/ConfirmSalesActionModal.tsx
+++ b/packages/features/sales-escrows/modals/ConfirmSalesActionModal.tsx
@@ -29,7 +29,7 @@ interface ConfirmSalesActionModalProps {
   escrow?: EscrowRecord;
   offer?: EscrowRecord;
   onSaleCancelled?: () => void;
-  setInProcess?: React.Dispatch<React.SetStateAction<boolean>>;
+  setInProcess?: (any) => void;
 }
 
 export const ConfirmSalesActionModal = ({
@@ -50,8 +50,9 @@ export const ConfirmSalesActionModal = ({
   const debug = useDebug();
 
   const _handleClose = async (confirm = false) => {
-    if (confirm && actor) {
-      if (isLoading) return;
+    if (!confirm || !actor || isLoading) return;
+
+    try {
       setIsLoading(true);
       setConfirmed(true);
       setInProcess?.(true);
@@ -67,10 +68,7 @@ export const ConfirmSalesActionModal = ({
               horizontal: 'right',
             },
           });
-          setInProcess?.(false);
           onSaleCancelled();
-          setIsLoading(false);
-          return handleClose(true);
         }
         enqueueSnackbar(`Error: ${endSaleResponse.err.flag_point}.`, {
           variant: 'error',
@@ -79,9 +77,6 @@ export const ConfirmSalesActionModal = ({
             horizontal: 'right',
           },
         });
-        setInProcess?.(false);
-        setIsLoading(false);
-        return handleClose(false);
       }
       if (action === 'withdraw') {
         if (!escrow) {
@@ -112,13 +107,7 @@ export const ConfirmSalesActionModal = ({
               horizontal: 'right',
             },
           });
-          setInProcess?.(false);
-          setIsLoading(false);
-          return handleClose(true);
         }
-        setInProcess?.(false);
-        setIsLoading(false);
-        return handleClose(false);
       }
 
       if (action === 'reject') {
@@ -149,13 +138,7 @@ export const ConfirmSalesActionModal = ({
               horizontal: 'right',
             },
           });
-          setInProcess?.(false);
-          setIsLoading(false);
-          return handleClose(true);
         }
-        setInProcess?.(false);
-        setIsLoading(false);
-        return handleClose(false);
       }
 
       const escrowReceipt: EscrowReceipt = {
@@ -203,18 +186,19 @@ export const ConfirmSalesActionModal = ({
                 horizontal: 'right',
               },
             });
-            setIsLoading(false);
-            return handleClose(true);
           }
-          setInProcess?.(false);
-          setIsLoading(false);
-          return handleClose(false);
         } catch (e) {
           debug.log(e);
         }
       }
+      handleClose(false);
+    } catch (e) {
+      debug.log(e);
+    } finally {
+      setInProcess?.(false);
+      setIsLoading(false);
+      handleClose(false);
     }
-    handleClose(false);
   };
 
   useEffect(() => {

--- a/packages/features/sales-escrows/modals/ManageEscrows.tsx
+++ b/packages/features/sales-escrows/modals/ManageEscrows.tsx
@@ -180,7 +180,7 @@ const ManageEscrowsModal = ({ open, handleClose, collection }: any) => {
 
       <ConfirmSalesActionModal
         openConfirmation={openConfirmation}
-        handleClose={handleCloseConf}
+        onClose={handleCloseConf}
         currentToken={selectdNFT}
         action={dialogAction}
         escrow={selectedEscrow}

--- a/packages/features/sales-escrows/modals/StartAuctionModal.tsx
+++ b/packages/features/sales-escrows/modals/StartAuctionModal.tsx
@@ -50,7 +50,7 @@ interface StartAuctionModalProps {
   open: boolean;
   handleClose: (any) => void;
   onSuccess: (any) => Promise<void>;
-  setInProcess: React.Dispatch<React.SetStateAction<boolean>>;
+  setInProcess: (any) => void;
 }
 
 export function StartAuctionModal({
@@ -78,9 +78,9 @@ export function StartAuctionModal({
     endDate,
     token: saleToken,
   }) => {
-    setInProgress(true);
-    setInProcess(true);
     try {
+      setInProgress(true);
+      setInProcess(true);
       const resp = await actor.market_transfer_nft_origyn({
         token_id: currentToken,
         sales_config: {
@@ -142,9 +142,10 @@ export function StartAuctionModal({
           horizontal: 'right',
         },
       });
+    } finally {
+      setInProgress(false);
+      setInProcess(false);
     }
-    setInProgress(false);
-    setInProcess(false);
   };
 
   const getValidationErrors = (err) => {

--- a/packages/features/sales-escrows/modals/StartAuctionModal.tsx
+++ b/packages/features/sales-escrows/modals/StartAuctionModal.tsx
@@ -45,7 +45,21 @@ const validationSchema = Yup.object({
     .default(dateNow),
 });
 
-export function StartAuctionModal({ currentToken, open, handleClose, onSuccess }: any) {
+interface StartAuctionModalProps {
+  currentToken: string;
+  open: boolean;
+  handleClose: (any) => void;
+  onSuccess: (any) => Promise<void>;
+  setInProcess: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export function StartAuctionModal({
+  currentToken,
+  open,
+  handleClose,
+  onSuccess,
+  setInProcess,
+}: StartAuctionModalProps) {
   const { actor } = React.useContext(AuthContext);
   const { enqueueSnackbar } = useSnackbar();
   const [errors, setErrors] = React.useState<any>({});
@@ -65,6 +79,7 @@ export function StartAuctionModal({ currentToken, open, handleClose, onSuccess }
     token: saleToken,
   }) => {
     setInProgress(true);
+    setInProcess(true);
     try {
       const resp = await actor.market_transfer_nft_origyn({
         token_id: currentToken,
@@ -129,6 +144,7 @@ export function StartAuctionModal({ currentToken, open, handleClose, onSuccess }
       });
     }
     setInProgress(false);
+    setInProcess(false);
   };
 
   const getValidationErrors = (err) => {

--- a/packages/features/sales-escrows/modals/StartAuctionModal.tsx
+++ b/packages/features/sales-escrows/modals/StartAuctionModal.tsx
@@ -48,9 +48,9 @@ const validationSchema = Yup.object({
 interface StartAuctionModalProps {
   currentToken: string;
   open: boolean;
-  onClose: (any) => void;
+  onClose: () => void;
   onSuccess: (any) => Promise<void>;
-  setInProcess: (boolean) => void;
+  onProcessing: (boolean) => void;
 }
 
 export function StartAuctionModal({
@@ -58,7 +58,7 @@ export function StartAuctionModal({
   open,
   onClose,
   onSuccess,
-  setInProcess,
+  onProcessing,
 }: StartAuctionModalProps) {
   const { actor } = React.useContext(AuthContext);
   const { enqueueSnackbar } = useSnackbar();
@@ -80,7 +80,7 @@ export function StartAuctionModal({
   }) => {
     try {
       setInProgress(true);
-      setInProcess(true);
+      onProcessing(true);
       const resp = await actor.market_transfer_nft_origyn({
         token_id: currentToken,
         sales_config: {
@@ -144,7 +144,7 @@ export function StartAuctionModal({
       });
     } finally {
       setInProgress(false);
-      setInProcess(false);
+      onProcessing(false);
     }
   };
 
@@ -178,7 +178,7 @@ export function StartAuctionModal({
 
   return (
     <div>
-      <Modal isOpened={open} closeModal={() => onClose(false)} size="md">
+      <Modal isOpened={open} closeModal={() => onClose()} size="md">
         <Container size="full" padding="48px">
           {success ? (
             <>
@@ -258,7 +258,7 @@ export function StartAuctionModal({
                     <br />
                     <HR />
                     <Flex align="center" justify="flex-end" gap={16}>
-                      <Button onClick={() => onClose(false)}>Cancel</Button>
+                      <Button onClick={() => onClose()}>Cancel</Button>
                       <Button type="submit">Start</Button>
                     </Flex>
                   </Flex>

--- a/packages/features/sales-escrows/modals/StartAuctionModal.tsx
+++ b/packages/features/sales-escrows/modals/StartAuctionModal.tsx
@@ -48,7 +48,7 @@ const validationSchema = Yup.object({
 interface StartAuctionModalProps {
   currentToken: string;
   open: boolean;
-  handleClose: (any) => void;
+  onClose: (any) => void;
   onSuccess: (any) => Promise<void>;
   setInProcess: (any) => void;
 }
@@ -56,7 +56,7 @@ interface StartAuctionModalProps {
 export function StartAuctionModal({
   currentToken,
   open,
-  handleClose,
+  onClose,
   onSuccess,
   setInProcess,
 }: StartAuctionModalProps) {
@@ -70,7 +70,7 @@ export function StartAuctionModal({
   const [success, setSuccess] = React.useState(false);
   const { tokens, activeTokens } = useTokensContext();
 
-  const handleStartAuction = async ({
+  const onStartAuction = async ({
     startPrice,
     buyNowPrice,
     reservePrice,
@@ -159,12 +159,12 @@ export function StartAuctionModal({
 
     return validationErrors;
   };
-  const handleSubmit = (e: any) => {
+  const onSubmit = (e: any) => {
     e.preventDefault();
     validationSchema
       .validate(values, { abortEarly: false })
       .then(() => {
-        handleStartAuction(values);
+        onStartAuction(values);
       })
       .catch(function (e) {
         const errs = getValidationErrors(e);
@@ -178,7 +178,7 @@ export function StartAuctionModal({
 
   return (
     <div>
-      <Modal isOpened={open} closeModal={() => handleClose(false)} size="md">
+      <Modal isOpened={open} closeModal={() => onClose(false)} size="md">
         <Container size="full" padding="48px">
           {success ? (
             <>
@@ -189,7 +189,7 @@ export function StartAuctionModal({
               </p>
               <br />
               <Flex justify="flex-end">
-                <Button onClick={handleClose}>Done</Button>
+                <Button onClick={onClose}>Done</Button>
               </Flex>
             </>
           ) : (
@@ -204,7 +204,7 @@ export function StartAuctionModal({
                 <>
                   <h2>Start an Auction</h2>
                   <br />
-                  <Flex as="form" onSubmit={handleSubmit} action="" flexFlow="column" gap={8}>
+                  <Flex as="form" onSubmit={onSubmit} action="" flexFlow="column" gap={8}>
                     <Select
                       label="Token"
                       name="token"
@@ -258,7 +258,7 @@ export function StartAuctionModal({
                     <br />
                     <HR />
                     <Flex align="center" justify="flex-end" gap={16}>
-                      <Button onClick={() => handleClose(false)}>Cancel</Button>
+                      <Button onClick={() => onClose(false)}>Cancel</Button>
                       <Button type="submit">Start</Button>
                     </Flex>
                   </Flex>

--- a/packages/features/sales-escrows/modals/StartAuctionModal.tsx
+++ b/packages/features/sales-escrows/modals/StartAuctionModal.tsx
@@ -50,7 +50,7 @@ interface StartAuctionModalProps {
   open: boolean;
   onClose: (any) => void;
   onSuccess: (any) => Promise<void>;
-  setInProcess: (any) => void;
+  setInProcess: (boolean) => void;
 }
 
 export function StartAuctionModal({

--- a/packages/features/sales-escrows/modals/StartEscrowModal.tsx
+++ b/packages/features/sales-escrows/modals/StartEscrowModal.tsx
@@ -17,7 +17,7 @@ export type StartEscrowModalProps = {
   open: boolean;
   handleClose: any;
   onSuccess: any;
-  setInProcess: React.Dispatch<React.SetStateAction<boolean>>;
+  setInProcess: (any) => void;
 };
 
 type FormErrors = {
@@ -154,13 +154,13 @@ export function StartEscrowModal({
 
   const startEscrow = async () => {
     try {
+      setIsTransacting(true);
+      setInProcess(true);
+
       if (isLoading || isTransacting || !activeWalletProvider || hasErrors() || !validateForm()) {
         debug.log('validation failed');
         return;
       }
-
-      setIsTransacting(true);
-      setInProcess(true);
 
       // gets the deposit info for the account number of the caller
       const saleInfo = await actor.sale_info_nft_origyn({ deposit_info: [] });

--- a/packages/features/sales-escrows/modals/StartEscrowModal.tsx
+++ b/packages/features/sales-escrows/modals/StartEscrowModal.tsx
@@ -17,7 +17,7 @@ export type StartEscrowModalProps = {
   open: boolean;
   onClose: any;
   onSuccess: any;
-  setInProcess: (boolean) => void;
+  onProcessing: (boolean) => void;
 };
 
 type FormErrors = {
@@ -31,7 +31,7 @@ export function StartEscrowModal({
   open,
   onClose,
   onSuccess,
-  setInProcess,
+  onProcessing,
 }: StartEscrowModalProps) {
   const debug = useDebug();
   const { actor, principal, activeWalletProvider } = React.useContext(AuthContext);
@@ -155,7 +155,7 @@ export function StartEscrowModal({
   const startEscrow = async () => {
     try {
       setIsTransacting(true);
-      setInProcess(true);
+      onProcessing(true);
 
       if (isLoading || isTransacting || !activeWalletProvider || hasErrors() || !validateForm()) {
         debug.log('validation failed');
@@ -279,7 +279,7 @@ export function StartEscrowModal({
       });
     } finally {
       setIsTransacting(false);
-      setInProcess(false);
+      onProcessing(false);
     }
   };
 

--- a/packages/features/sales-escrows/modals/StartEscrowModal.tsx
+++ b/packages/features/sales-escrows/modals/StartEscrowModal.tsx
@@ -17,6 +17,7 @@ export type StartEscrowModalProps = {
   open: boolean;
   handleClose: any;
   onSuccess: any;
+  setInProcess: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 type FormErrors = {
@@ -30,6 +31,7 @@ export function StartEscrowModal({
   open,
   handleClose,
   onSuccess,
+  setInProcess,
 }: StartEscrowModalProps) {
   const debug = useDebug();
   const { actor, principal, activeWalletProvider } = React.useContext(AuthContext);
@@ -158,6 +160,7 @@ export function StartEscrowModal({
       }
 
       setIsTransacting(true);
+      setInProcess(true);
 
       // gets the deposit info for the account number of the caller
       const saleInfo = await actor.sale_info_nft_origyn({ deposit_info: [] });
@@ -276,6 +279,7 @@ export function StartEscrowModal({
       });
     } finally {
       setIsTransacting(false);
+      setInProcess(false);
     }
   };
 

--- a/packages/features/sales-escrows/modals/StartEscrowModal.tsx
+++ b/packages/features/sales-escrows/modals/StartEscrowModal.tsx
@@ -17,7 +17,7 @@ export type StartEscrowModalProps = {
   open: boolean;
   onClose: any;
   onSuccess: any;
-  setInProcess: (any) => void;
+  setInProcess: (boolean) => void;
 };
 
 type FormErrors = {

--- a/packages/features/sales-escrows/modals/StartEscrowModal.tsx
+++ b/packages/features/sales-escrows/modals/StartEscrowModal.tsx
@@ -15,7 +15,7 @@ export type StartEscrowModalProps = {
   odc: OdcDataWithSale;
   escrowType: EscrowType;
   open: boolean;
-  handleClose: any;
+  onClose: any;
   onSuccess: any;
   setInProcess: (any) => void;
 };
@@ -29,7 +29,7 @@ export function StartEscrowModal({
   odc,
   escrowType,
   open,
-  handleClose,
+  onClose,
   onSuccess,
   setInProcess,
 }: StartEscrowModalProps) {
@@ -250,7 +250,7 @@ export function StartEscrowModal({
             horizontal: 'right',
           },
         });
-        handleCustomClose(true);
+        onCustomClose(true);
         refreshAllBalances(false, principal);
         setSuccess(true);
         onSuccess();
@@ -263,7 +263,7 @@ export function StartEscrowModal({
             horizontal: 'right',
           },
         });
-        handleCustomClose(true);
+        onCustomClose(true);
         refreshAllBalances(false, principal);
         setSuccess(true);
         onSuccess();
@@ -283,11 +283,11 @@ export function StartEscrowModal({
     }
   };
 
-  const handleCustomClose = (value: any) => {
+  const onCustomClose = (value: any) => {
     setIsLoading(false);
     setIsTransacting(false);
     setSuccess(false);
-    handleClose(value);
+    onClose(value);
   };
 
   const onFormSubmitted = async (e: any) => {
@@ -297,14 +297,14 @@ export function StartEscrowModal({
 
   return (
     <div>
-      <Modal isOpened={open} closeModal={() => handleCustomClose} size="md">
+      <Modal isOpened={open} closeModal={() => onCustomClose} size="md">
         <Container as="form" onSubmit={onFormSubmitted} size="full" padding="48px" smPadding="8px">
           {success ? (
             <>
               <h2>Success!</h2>
               <p className="secondary_color">All the transactions were made successfully.</p>
               <Flex justify="flex-end">
-                <Button onClick={handleCustomClose}>Done</Button>
+                <Button onClick={onCustomClose}>Done</Button>
               </Flex>
             </>
           ) : (
@@ -389,7 +389,7 @@ export function StartEscrowModal({
                         </>
                       )}
                       <Flex align="center" justify="flex-end" gap={16}>
-                        <Button btnType="outlined" onClick={() => handleCustomClose(false)}>
+                        <Button btnType="outlined" onClick={() => onCustomClose(false)}>
                           Cancel
                         </Button>
                         <Button btnType="accent" type="submit" disabled={hasErrors()}>

--- a/packages/features/sales-escrows/pages/NFTPage/components/OffersPanel.tsx
+++ b/packages/features/sales-escrows/pages/NFTPage/components/OffersPanel.tsx
@@ -9,9 +9,10 @@ import { EscrowType } from '../../../modals/StartEscrowModal';
 export interface OffersPanelProps {
   odc: OdcDataWithSale;
   onOpenEscrowModal: (escrowType: EscrowType) => void;
+  inProcess: boolean;
 }
 
-export const OffersPanel = ({ odc, onOpenEscrowModal }: OffersPanelProps) => {
+export const OffersPanel = ({ odc, onOpenEscrowModal, inProcess }: OffersPanelProps) => {
   const debug = useDebug();
   const { principal, actor } = useContext(AuthContext);
   const [existingOffer, setExistingOffer] = useState<any | null>(null);
@@ -66,7 +67,7 @@ export const OffersPanel = ({ odc, onOpenEscrowModal }: OffersPanelProps) => {
           </Flex>
         </Container>
       ) : (
-        <Button btnType="accent" onClick={() => onOpenEscrowModal('Offer')}>
+        <Button btnType="accent" onClick={() => onOpenEscrowModal('Offer')} disabled={inProcess}>
           Make an Offer
         </Button>
       )}

--- a/packages/features/sales-escrows/pages/NFTPage/index.tsx
+++ b/packages/features/sales-escrows/pages/NFTPage/index.tsx
@@ -428,16 +428,16 @@ export const NFTPage = () => {
               currentToken={odc?.id}
               action={dialogAction}
               onSaleCancelled={fetchData}
-              setInProcess={setInProcess}
+              onProcessing={setInProcess}
             />
           )}
           {openAuction && (
             <StartAuctionModal
               open={openAuction}
-              handleClose={handleClose}
+              onClose={handleClose}
               onSuccess={fetchOdc}
               currentToken={odc?.id}
-              setInProcess={setInProcess}
+              onProcessing={setInProcess}
             />
           )}
           {openEscrowModal && (
@@ -447,7 +447,7 @@ export const NFTPage = () => {
               odc={odc}
               escrowType={escrowType}
               onSuccess={fetchOdc}
-              setInProcess={setInProcess}
+              onProcessing={setInProcess}
             />
           )}
         </Flex>

--- a/packages/features/sales-escrows/pages/NFTPage/index.tsx
+++ b/packages/features/sales-escrows/pages/NFTPage/index.tsx
@@ -424,7 +424,7 @@ export const NFTPage = () => {
           {openConfirmation && (
             <ConfirmSalesActionModal
               openConfirmation={openConfirmation}
-              handleClose={handleClose}
+              onClose={handleClose}
               currentToken={odc?.id}
               action={dialogAction}
               onSaleCancelled={fetchData}
@@ -443,7 +443,7 @@ export const NFTPage = () => {
           {openEscrowModal && (
             <StartEscrowModal
               open={openEscrowModal}
-              handleClose={handleCloseEscrow}
+              onClose={handleCloseEscrow}
               odc={odc}
               escrowType={escrowType}
               onSuccess={fetchOdc}

--- a/packages/features/sales-escrows/pages/NFTPage/index.tsx
+++ b/packages/features/sales-escrows/pages/NFTPage/index.tsx
@@ -48,6 +48,7 @@ export const NFTPage = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [openEscrowModal, setOpenEscrowModal] = React.useState(false);
   const [escrowType, setEscrowType] = React.useState<EscrowType>();
+  const [inProcess, setInProcess] = useState<boolean>(false);
   const { open } = useDialog();
 
   const logout = () => {
@@ -268,6 +269,7 @@ export const NFTPage = () => {
                                       <Button
                                         btnType="accent"
                                         onClick={() => onOpenEscrowModal('BuyNow')}
+                                        disabled={inProcess}
                                       >
                                         Buy Now
                                       </Button>
@@ -279,12 +281,20 @@ export const NFTPage = () => {
 
                                   {principalId === verifyOwner ? (
                                     odc.currentBid == 0 || odc.auctionNotStarted ? (
-                                      <Button btnType="accent" onClick={handleClickOpenEsc}>
+                                      <Button
+                                        btnType="accent"
+                                        onClick={handleClickOpenEsc}
+                                        disabled={inProcess}
+                                      >
                                         Cancel Sale
                                       </Button>
                                     ) : BigInt(Number(nftEndSale || 9 * 1e30)) <
                                       currentTimeInNanos ? (
-                                      <Button btnType="accent" onClick={handleClickOpenEsc}>
+                                      <Button
+                                        btnType="accent"
+                                        onClick={handleClickOpenEsc}
+                                        disabled={inProcess}
+                                      >
                                         Finish Sale
                                       </Button>
                                     ) : (
@@ -297,6 +307,7 @@ export const NFTPage = () => {
                                     <Button
                                       btnType="outlined"
                                       onClick={() => onOpenEscrowModal('Bid')}
+                                      disabled={inProcess}
                                     >
                                       Place Bid
                                     </Button>
@@ -307,11 +318,19 @@ export const NFTPage = () => {
                                   )}
                                 </>
                               ) : principalId === verifyOwner ? (
-                                <Button btnType="accent" onClick={handleClickOpen}>
+                                <Button
+                                  btnType="accent"
+                                  onClick={handleClickOpen}
+                                  disabled={inProcess}
+                                >
                                   Start an Auction
                                 </Button>
                               ) : (
-                                <OffersPanel odc={odc} onOpenEscrowModal={onOpenEscrowModal} />
+                                <OffersPanel
+                                  odc={odc}
+                                  onOpenEscrowModal={onOpenEscrowModal}
+                                  inProcess={inProcess}
+                                />
                               )}
                             </Flex>
                           )}
@@ -409,6 +428,7 @@ export const NFTPage = () => {
               currentToken={odc?.id}
               action={dialogAction}
               onSaleCancelled={fetchData}
+              setInProcess={setInProcess}
             />
           )}
           {openAuction && (
@@ -417,6 +437,7 @@ export const NFTPage = () => {
               handleClose={handleClose}
               onSuccess={fetchOdc}
               currentToken={odc?.id}
+              setInProcess={setInProcess}
             />
           )}
           {openEscrowModal && (
@@ -426,6 +447,7 @@ export const NFTPage = () => {
               odc={odc}
               escrowType={escrowType}
               onSuccess={fetchOdc}
+              setInProcess={setInProcess}
             />
           )}
         </Flex>


### PR DESCRIPTION
Added the hook` const [inProcess, setInProcess] = useState<boolean>(false);` in NFTPage > index.tsx

Added the prop `setInProcess` to : 
• ConfirmSalesActionModal
• StartAuctionModal
• StartEscrowModal 

This prop sets inProcess = true during these following actions: 
• Make an offer
• Start An Auction
• Cancel a Sale
• Finish a Sale
• Place a bid

📷 
_In this use case, I closed the modal during a Cancel Sale. The button Cancel Sale is disabled._
<img width="623" alt="Schermata 2023-03-06 alle 15 13 49" src="https://user-images.githubusercontent.com/68469149/223232417-89072231-c1a5-413a-b647-e8014ded7925.png">



