### PR TITLE
Eng-1444 placeholder image

### DIFF
--- a/packages/apps/marketplace/src/pages/Marketplace/index.tsx
+++ b/packages/apps/marketplace/src/pages/Marketplace/index.tsx
@@ -3,7 +3,7 @@ import { useSnackbar } from 'notistack';
 import { useDebug } from '@dapp/features-debug-provider';
 import { AuthContext, useRoute } from '@dapp/features-authentication';
 import { LoadingContainer, TokenIcon } from '@dapp/features-components';
-import { PlaceholderImage } from '@dapp/common-assets';
+import { PlaceholderIcon } from '@dapp/common-assets';
 import { useMarketplace } from '../../components/context';
 import {
   Card,
@@ -195,12 +195,11 @@ const Marketplace = () => {
                             src={`https://prptl.io/-/${canisterId}/collection/preview`}
                             alt="text"
                             style={{ width: 200 }}
-                            onError={(e) => {
-                              e.currentTarget.src = PlaceholderImage;
-                            }}
                           />
                         ) : (
-                          <Image src={PlaceholderImage} alt="text" style={{ width: 200 }} />
+                          <Flex align="center" justify="center">
+                            <PlaceholderIcon width={200} height={200} />
+                          </Flex>
                         )}
                         <Flex flexFlow="column" justify="space-between" gap={8}>
                           <h2>
@@ -261,20 +260,15 @@ const Marketplace = () => {
                                     style={{ overflow: 'hidden', height: '100%' }}
                                   >
                                     {odc.hasPreviewAsset ? (
-                                      <img
-                                        style={{ width: '100%' }}
+                                      <Image
+                                        style={{ width: 200 }}
                                         src={`https://${canisterId}.raw.ic0.app/-/${odc?.id}/preview`}
                                         alt=""
-                                        onError={(e) => {
-                                          e.currentTarget.src = PlaceholderImage;
-                                        }}
                                       />
                                     ) : (
-                                      <Image
-                                        src={PlaceholderImage}
-                                        alt="text"
-                                        style={{ width: 200 }}
-                                      />
+                                      <Flex align="center" justify="center">
+                                        <PlaceholderIcon width={200} height={200} />
+                                      </Flex>
                                     )}
                                     <Container
                                       style={{ height: '100%' }}

--- a/packages/apps/vault/src/pages/Vault/index.tsx
+++ b/packages/apps/vault/src/pages/Vault/index.tsx
@@ -26,7 +26,7 @@ import {
   ShowMoreBlock,
 } from '@origyn-sa/origyn-art-ui';
 import { Principal } from '@dfinity/principal';
-import { PlaceholderImage } from '@dapp/common-assets';
+import { PlaceholderIcon } from '@dapp/common-assets';
 
 const GuestContainer = () => {
   const { open } = useDialog();
@@ -501,16 +501,11 @@ const VaultPage = () => {
                             <StyledCollectionImg
                               src={`https://prptl.io/-/${canisterId}/collection/preview`}
                               alt=""
-                              onError={(e) => {
-                                e.currentTarget.src = PlaceholderImage;
-                              }}
                             />
                           ) : (
-                            <StyledCollectionImg
-                              src={PlaceholderImage}
-                              alt="text"
-                              style={{ width: 200 }}
-                            />
+                            <Flex justify="center" align="center" style={{ height: '100%' }}>
+                              <PlaceholderIcon width={96} height={96} />
+                            </Flex>
                           )}
                           <Flex flexFlow="column" fullWidth justify="space-between" gap={8}>
                             <Flex
@@ -619,21 +614,20 @@ const VaultPage = () => {
                                     >
                                       {odc.hasPreviewAsset ? (
                                         <StyledNFTImg
-                                          onError={(e) => {
-                                            e.currentTarget.src = PlaceholderImage;
-                                          }}
                                           src={`https://${canisterId}.raw.ic0.app/-/${odc?.id}/preview`}
                                           alt=""
                                         />
                                       ) : (
-                                        <StyledNFTImg
-                                          src={PlaceholderImage}
-                                          alt=""
-                                          onError={(e) => {
-                                            e.target.onerror = null; // prevents looping
-                                            e.currentTarget.className += ' errorImage';
-                                          }}
-                                        />
+                                        <Flex
+                                          justify="center"
+                                          align="center"
+                                          style={{ height: '100%' }}
+                                        >
+                                          <PlaceholderIcon
+                                            width={'100%'}
+                                            height={`calc(15vw - 20px)`}
+                                          />
+                                        </Flex>
                                       )}
                                       <Container
                                         style={{ height: '100%' }}

--- a/packages/common/assets/src/index.ts
+++ b/packages/common/assets/src/index.ts
@@ -8,5 +8,7 @@ import OrigynLogo from './logo.svg';
 import QuestionIcon from './question.svg';
 // @ts-ignore 
 import PlaceholderImage from './placeholder.png';
+// @ts-ignore
+import PlaceholderIcon from './placeholder.svg';
 
-export { ICPIcon, OrigynLogo, OGYIcon, QuestionIcon, PlaceholderImage };
+export { ICPIcon, OrigynLogo, OGYIcon, QuestionIcon, PlaceholderImage, PlaceholderIcon };

--- a/packages/common/assets/src/placeholder.svg
+++ b/packages/common/assets/src/placeholder.svg
@@ -1,0 +1,26 @@
+<svg viewBox="0 0 330 330" fill="none" xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink">
+  <rect width="100%" height="100%" fill="url(#pattern0)" />
+  <path d="M164.9 99.4482L222.521 132.714L165.284 165.987L107.653 132.712L164.9 99.4482Z" fill="#DCDCDC"
+    stroke="#121212" stroke-width="0.775625" />
+  <path d="M165.673 166.659L222.906 133.388L222.731 197.063L165.488 230.325L165.673 166.659Z" fill="#C5C5C5"
+    stroke="#121212" stroke-width="0.775625" />
+  <path d="M107.268 133.384L164.899 166.659L164.714 230.329L107.092 197.063L107.268 133.384Z" fill="#898989"
+    stroke="#121212" stroke-width="0.775625" />
+  <rect x="34" y="34" width="262" height="262" rx="131" stroke="url(#paint0_linear_2509_6686)" stroke-width="2" />
+  <defs>
+    <pattern id="pattern0" patternContentUnits="objectBoundingBox" width="1" height="1">
+      <use xlinkHref="#image0_2509_6686" transform="scale(0.00123457)" />
+    </pattern>
+    <linearGradient id="paint0_linear_2509_6686" x1="165" y1="33" x2="165" y2="297" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#EED926" />
+      <stop offset="0.135417" stop-color="#EF8712" />
+      <stop offset="0.244792" stop-color="#DD1C1F" />
+      <stop offset="0.385417" stop-color="#833183" />
+      <stop offset="0.510417" stop-color="#363373" />
+      <stop offset="0.604167" stop-color="#1A87C4" />
+      <stop offset="0.75" stop-color="#1E2345" />
+      <stop offset="0.833333" stop-color="#65AE35" />
+      <stop offset="1" stop-color="#046D31" />
+    </linearGradient>
+  </defs>
+</svg>

--- a/packages/features/sales-escrows/modals/ManageEscrows.tsx
+++ b/packages/features/sales-escrows/modals/ManageEscrows.tsx
@@ -114,7 +114,10 @@ const ManageEscrowsModal = ({ open, handleClose, collection }: any) => {
   };
 
   useEffect(() => {
-    getBalances();
+    if (open && actor) {
+      getBalances();
+      totalAmount();
+    }
     totalAmount();
   }, [open, withdrawEscrow, actor]);
 

--- a/packages/features/sales-escrows/modals/ManageEscrows.tsx
+++ b/packages/features/sales-escrows/modals/ManageEscrows.tsx
@@ -29,9 +29,9 @@ const ManageEscrowsModal = ({ open, handleClose, collection }: any) => {
   // const [totalAm, setTotalAm] = useState();
 
   //-----------------
-  const Balance = async () => {
+  const getBalances = async () => {
     try {
-      const response = await actor?.balance_of_nft_origyn({ principal });
+      const response = await actor.balance_of_nft_origyn({ principal });
       debug.log('response from actor?.balance_of_nft_origyn({ principal })');
       debug.log(JSON.stringify(response, null, 2));
       if ('err' in response) {
@@ -114,9 +114,9 @@ const ManageEscrowsModal = ({ open, handleClose, collection }: any) => {
   };
 
   useEffect(() => {
-    Balance();
+    getBalances();
     totalAmount();
-  }, [open, withdrawEscrow]);
+  }, [open, withdrawEscrow, actor]);
 
   return (
     <>

--- a/packages/features/sales-escrows/modals/ManageEscrows.tsx
+++ b/packages/features/sales-escrows/modals/ManageEscrows.tsx
@@ -119,7 +119,7 @@ const ManageEscrowsModal = ({ open, handleClose, collection }: any) => {
       totalAmount();
     }
     totalAmount();
-  }, [open, withdrawEscrow, actor]);
+  }, [open, actor]);
 
   return (
     <>

--- a/packages/features/sales-escrows/modals/bidsReceivedTab.tsx
+++ b/packages/features/sales-escrows/modals/bidsReceivedTab.tsx
@@ -4,6 +4,7 @@ import { TokenIcon } from '@dapp/features-components';
 import { AuthContext } from '@dapp/features-authentication';
 import { OdcDataWithSale, parseOdc, toLargerUnit } from '@dapp/utils';
 import { formatDistanceToNow } from 'date-fns';
+import { PlaceholderIcon } from '@dapp/common-assets';
 const styles = {
   gridContainer: {
     display: 'grid',
@@ -71,11 +72,15 @@ export const BidsReceivedTab = ({
             {receivedActivedBids.map((bid: ReceivedActiveBidsProps) => (
               <>
                 <div style={styles.gridItem}>
-                  <img
-                    style={{ width: '42px', height: '42px', borderRadius: '12px' }}
-                    src={`https://${canisterId}.raw.ic0.app/-/${bid.token_id}/preview`}
-                    alt=""
-                  />
+                  {bid.hasPreviewAsset ? (
+                    <img
+                      style={{ width: '42px', height: '42px', borderRadius: '12px' }}
+                      src={`https://${canisterId}.raw.ic0.app/-/${bid.token_id}/preview`}
+                      alt=""
+                    />
+                  ) : (
+                    <PlaceholderIcon width={42} height={42} />
+                  )}
                 </div>
                 <div style={styles.gridItem}>
                   <span>{bid.token_id}</span>

--- a/packages/features/sales-escrows/modals/bidsSentTab.tsx
+++ b/packages/features/sales-escrows/modals/bidsSentTab.tsx
@@ -2,9 +2,11 @@ import React, { useState, useEffect, useContext } from 'react';
 import { HR, theme } from '@origyn-sa/origyn-art-ui';
 import { TokenIcon } from '@dapp/features-components';
 import { AuthContext } from '@dapp/features-authentication';
-import { OdcDataWithSale, parseOdc, toLargerUnit } from '@dapp/utils';
+import { OdcDataWithSale, parseOdcs, toLargerUnit } from '@dapp/utils';
 import { formatDistanceToNow } from 'date-fns';
 import { PlaceholderIcon } from '@dapp/common-assets';
+import { useDebug } from '@dapp/features-debug-provider';
+import { EscrowRecord } from '@dapp/common-types';
 
 const styles = {
   gridContainer: {
@@ -22,7 +24,7 @@ const styles = {
 };
 
 interface BidsSentTabProps {
-  bidsSent: any[];
+  bidsSent: EscrowRecord[];
   collection: any;
   canisterId: string;
 }
@@ -34,28 +36,36 @@ interface SentActiveBidsProps extends OdcDataWithSale {
 
 export const BidsSentTab = ({ bidsSent: bidsSent, collection, canisterId }: BidsSentTabProps) => {
   const { actor } = useContext(AuthContext);
+  const debug = useDebug();
   const [sentActivedBids, setSentActiveBids] = useState<SentActiveBidsProps[]>([]);
   const currentTimeInNanos = BigInt(new Date().getTime() * 1e6);
 
   const parseBids = async () => {
-    bidsSent.map(async (bid) => {
-      const r: any = await actor.nft_origyn(bid.token_id);
-      if ('err' in r) {
-        throw new Error(Object.keys(r.err)[0]);
+    try {
+      const tokenIds = bidsSent.map((offer) => offer.token_id);
+      const odcDataRaw = await actor?.nft_batch_origyn(tokenIds);
+
+      if (odcDataRaw.err) {
+        throw new Error('Unable to retrieve metadata of tokens.');
       }
 
-      let parsedOdc: OdcDataWithSale = parseOdc(r['ok']);
-      let sentBid: SentActiveBidsProps = {
-        ...parsedOdc,
-        token_id: bid.token_id,
-        amount: toLargerUnit(Number(bid.amount), Number(bid.token.ic.decimals)).toString(),
-        symbol: bid.token.ic.symbol,
-      };
-      if (sentBid.auction?.end_date > currentTimeInNanos) {
-        // Add only the Active Bids
-        setSentActiveBids((prev) => [...prev, sentBid]);
-      }
-    });
+      const parsedOdcs = parseOdcs(odcDataRaw);
+      parsedOdcs.map((odc: OdcDataWithSale, index) => {
+        const bid = bidsSent[index];
+        let sentBid: SentActiveBidsProps = {
+          ...odc,
+          token_id: bid.token_id,
+          amount: toLargerUnit(Number(bid.amount), Number(bid.token['ic'].decimals)).toString(),
+          symbol: bid.token['ic'].symbol,
+        };
+        if (sentBid.auction?.end_date > currentTimeInNanos) {
+          // Add only the Active Bids
+          setSentActiveBids((prev) => [...prev, sentBid]);
+        }
+      });
+    } catch (e) {
+      debug.log(e);
+    }
   };
 
   useEffect(() => {

--- a/packages/features/sales-escrows/modals/bidsSentTab.tsx
+++ b/packages/features/sales-escrows/modals/bidsSentTab.tsx
@@ -4,6 +4,7 @@ import { TokenIcon } from '@dapp/features-components';
 import { AuthContext } from '@dapp/features-authentication';
 import { OdcDataWithSale, parseOdc, toLargerUnit } from '@dapp/utils';
 import { formatDistanceToNow } from 'date-fns';
+import { PlaceholderIcon } from '@dapp/common-assets';
 
 const styles = {
   gridContainer: {
@@ -69,16 +70,20 @@ export const BidsSentTab = ({ bidsSent: bidsSent, collection, canisterId }: Bids
             {sentActivedBids.map((bid: any, index: number) => (
               <>
                 <div key={index} style={styles.gridItem}>
-                  <img
-                    style={{
-                      width: '42px',
-                      borderRadius: '12px',
-                      marginTop: 'auto',
-                      marginBottom: 'auto',
-                    }}
-                    src={`https://${canisterId}.raw.ic0.app/-/${bid.token_id}/preview`}
-                    alt=""
-                  />
+                  {bid.hasPreviewAsset ? (
+                    <img
+                      style={{
+                        width: '42px',
+                        borderRadius: '12px',
+                        marginTop: 'auto',
+                        marginBottom: 'auto',
+                      }}
+                      src={`https://${canisterId}.raw.ic0.app/-/${bid.token_id}/preview`}
+                      alt=""
+                    />
+                  ) : (
+                    <PlaceholderIcon width={42} height={42} />
+                  )}
                 </div>
                 <div style={styles.gridItem}>
                   <div>

--- a/packages/features/sales-escrows/modals/offersReceivedTab.tsx
+++ b/packages/features/sales-escrows/modals/offersReceivedTab.tsx
@@ -1,7 +1,10 @@
-import React from 'react';
-import { Button, HR, theme } from '@origyn-sa/origyn-art-ui';
-import { toLargerUnit } from '@dapp/utils';
+import React, { useState, useEffect, useContext } from 'react';
 import { TokenIcon } from '@dapp/features-components';
+import { AuthContext } from '@dapp/features-authentication';
+import { Button, HR, theme } from '@origyn-sa/origyn-art-ui';
+import { OdcDataWithSale, parseOdcs, toLargerUnit } from '@dapp/utils';
+import { PlaceholderIcon } from '@dapp/common-assets';
+import { EscrowRecord } from '@dapp/common-types';
 
 const styles = {
   gridContainer: {
@@ -19,11 +22,17 @@ const styles = {
 };
 
 interface OffersTabProps {
-  offersReceived: any[];
+  offersReceived: EscrowRecord[];
   collection: any;
   canisterId: string;
   handleClickOpen: (esc: any, token_id: any) => void;
   handleClickOpenRej: (esc: any) => void;
+}
+
+interface ReceivedOffersProps extends OdcDataWithSale {
+  token_id: string;
+  amount: string;
+  symbol: string;
 }
 
 export const OffersReceivedTab = ({
@@ -33,42 +42,74 @@ export const OffersReceivedTab = ({
   handleClickOpen,
   handleClickOpenRej,
 }: OffersTabProps) => {
+  const { actor } = useContext(AuthContext);
+  const [receivedOffers, setReceivedOffers] = useState<ReceivedOffersProps[]>([]);
+
+  const parseOffers = async () => {
+    const tokenIds = offers.map((offer) => offer.token_id);
+    const odcDataRaw = await actor?.nft_batch_origyn(tokenIds);
+
+    if (odcDataRaw.err) {
+      throw new Error('Unable to retrieve metadata of tokens.');
+    }
+
+    const parsedOdcs = parseOdcs(odcDataRaw);
+    parsedOdcs.map((odc: OdcDataWithSale, index) => {
+      const offer = offers[index];
+      let sentOffer: ReceivedOffersProps = {
+        ...odc,
+        token_id: offer.token_id,
+        amount: toLargerUnit(Number(offer.amount), Number(offer.token['ic'].decimals)).toString(),
+        symbol: offer.token['ic'].symbol,
+      };
+      setReceivedOffers((prev) => [...prev, sentOffer]);
+    });
+  };
+
+  useEffect(() => {
+    parseOffers();
+  }, []);
+
   return (
     <>
       {offers.length > 0 ? (
         <div>
           <HR marginTop={16} marginBottom={16} />
           <div style={styles.gridContainer}>
-            {offers.map((esc: any) => (
+            {receivedOffers.map((offer: ReceivedOffersProps) => (
               <>
                 <div style={styles.gridItem}>
-                  <img
-                    style={{ width: '42px', height: '42px', borderRadius: '12px' }}
-                    src={`https://${canisterId}.raw.ic0.app/-/${esc.token_id}/preview`}
-                    alt=""
-                  />
+                  {offer.hasPreviewAsset ? (
+                    <img
+                      style={{ width: 'auto', height: '42px', borderRadius: '12px' }}
+                      src={`https://${canisterId}.raw.ic0.app/-/${offer.token_id}/preview`}
+                      alt=""
+                    />
+                  ) : (
+                    <PlaceholderIcon width={42} height={42} />
+                  )}
                 </div>
                 <div style={styles.gridItem}>
-                  <span>{esc.token_id}</span>
+                  <span>{offer.token_id}</span>
                   <br />
                   <span style={{ color: theme.colors.SECONDARY_TEXT }}>{collection.name}</span>
                 </div>
                 <div style={styles.gridItem}>
                   <p style={{ color: theme.colors.SECONDARY_TEXT }}>Amount</p>
-                  <TokenIcon symbol={esc.token.ic.symbol} />
-                  {`${toLargerUnit(Number(esc.amount), Number(esc.token.ic.decimals))}`}
+                  <TokenIcon symbol={offer.tokenSymbol} />
+                  {offer.amount}
                 </div>
                 <div style={styles.gridItem}>
                   <Button
                     btnType="filled"
                     size="small"
-                    onClick={() => handleClickOpen(esc, esc.token_id)}
+                    onClick={() => handleClickOpen(offer, offer.token_id)}
                   >
                     Accept
                   </Button>
                 </div>
                 <div style={styles.gridItem}>
-                  <Button btnType="outlined" size="small" onClick={() => handleClickOpenRej(esc)}>
+                  <Button btnType="outlined" size="small" onClick={() => handleClickOpenRej(offer)}>
                     Reject
                   </Button>
                 </div>

--- a/packages/features/sales-escrows/modals/offersSentTab.tsx
+++ b/packages/features/sales-escrows/modals/offersSentTab.tsx
@@ -1,7 +1,11 @@
-import React from 'react';
-import { Button, HR, theme } from '@origyn-sa/origyn-art-ui';
-import { toLargerUnit } from '@dapp/utils';
+import React, { useState, useEffect, useContext } from 'react';
 import { TokenIcon } from '@dapp/features-components';
+import { AuthContext } from '@dapp/features-authentication';
+import { Button, HR, theme } from '@origyn-sa/origyn-art-ui';
+import { OdcDataWithSale, parseOdcs, toLargerUnit } from '@dapp/utils';
+import { PlaceholderIcon } from '@dapp/common-assets';
+import { useDebug } from '@dapp/features-debug-provider';
+import { EscrowRecord } from '@dapp/common-types';
 
 const styles = {
   gridContainer: {
@@ -19,10 +23,17 @@ const styles = {
 };
 
 interface OffersSentTabProps {
-  offersSent: any[];
+  offersSent: EscrowRecord[];
   collection: any;
   canisterId: string;
   withdrawEscrow: (esc: any, token_id: any) => void;
+}
+
+interface SentOffersProps extends OdcDataWithSale {
+  token_id: string;
+  amount: string;
+  symbol: string;
+  lock_to_date: any;
 }
 
 export const OffersSentTab = ({
@@ -31,29 +42,64 @@ export const OffersSentTab = ({
   canisterId,
   withdrawEscrow,
 }: OffersSentTabProps) => {
+  const debug = useDebug();
+  const { actor } = useContext(AuthContext);
+  const [sentOffers, setSentOffers] = useState<SentOffersProps[]>([]);
+
+  const parseOffers = async () => {
+    const tokenIds = offersSent.map((offer) => offer.token_id);
+    const odcDataRaw = await actor?.nft_batch_origyn(tokenIds);
+
+    if (odcDataRaw.err) {
+      debug.error(odcDataRaw.err);
+      throw new Error('Unable to retrieve metadata of tokens.');
+    }
+
+    const parsedOdcs = parseOdcs(odcDataRaw);
+    parsedOdcs.map((odc: OdcDataWithSale, index) => {
+      const offer = offersSent[index];
+      let sentOffer: SentOffersProps = {
+        ...odc,
+        token_id: offer.token_id,
+        amount: toLargerUnit(Number(offer.amount), Number(offer.token['ic'].decimals)).toString(),
+        symbol: offer.token['ic'].symbol,
+        lock_to_date: offer.lock_to_date,
+      };
+      setSentOffers((prev) => [...prev, sentOffer]);
+    });
+  };
+
+  useEffect(() => {
+    parseOffers();
+  }, []);
+
   return (
     <>
       {offersSent.length > 0 ? (
         <div>
           <HR marginTop={16} marginBottom={16} />
           <div style={styles.gridContainer}>
-            {offersSent.map((esc: any, index: number) => (
+            {sentOffers.map((offer: SentOffersProps, index: number) => (
               <>
                 <div key={index} style={styles.gridItem}>
-                  <img
-                    style={{
-                      width: '42px',
-                      borderRadius: '12px',
-                      marginTop: 'auto',
-                      marginBottom: 'auto',
-                    }}
-                    src={`https://${canisterId}.raw.ic0.app/-/${esc.token_id}/preview`}
-                    alt=""
-                  />
+                  {offer.hasPreviewAsset ? (
+                    <img
+                      style={{ height: '42px', width: 'auto', borderRadius: '12px' }}
+                      src={`https://${canisterId}.raw.ic0.app/-/${offer.token_id}/preview`}
+                      alt=""
+                    />
+                  ) : (
+                    <PlaceholderIcon
+                      width={42}
+                      height={42}
+                      marginTop={'auto'}
+                      marginBottom={'auto'}
+                    />
+                  )}
                 </div>
                 <div style={styles.gridItem}>
                   <div>
-                    <p>{esc.token_id}</p>
+                    <p>{offer.token_id}</p>
                   </div>
 
                   <span style={{ color: theme.colors.SECONDARY_TEXT }}>{collection.name}</span>
@@ -62,30 +108,27 @@ export const OffersSentTab = ({
                   <span style={{ color: theme.colors.SECONDARY_TEXT }}>Amount</span>
                   <br />
                   <div>
-                    <TokenIcon symbol={esc.token.ic.symbol} />
-                    <span>{`${toLargerUnit(
-                      Number(esc.amount),
-                      Number(esc.token.ic.decimals),
-                    )}`}</span>
+                    <TokenIcon symbol={offer.token.symbol} />
+                    {offer.amount}
                   </div>
                 </div>
                 <div style={styles.gridItem}>
                   <span style={{ color: theme.colors.SECONDARY_TEXT }}>Status</span>
                   <br />
                   <span>
-                    {esc.lock_to_date
-                      ? Date.now() * 1e6 > parseInt(esc.lock_to_date)
+                    {offer.lock_to_date
+                      ? Date.now() * 1e6 > parseInt(offer.lock_to_date)
                         ? 'Locked'
                         : 'Done'
                       : 'Lock date not present'}
                   </span>
                 </div>
                 <div style={styles.gridItem}>
-                  {Date.now() * 1e6 > parseInt(esc.lock_to_date) ? (
+                  {Date.now() * 1e6 > parseInt(offer.lock_to_date) ? (
                     <Button
                       btnType="filled"
                       size="small"
-                      onClick={() => withdrawEscrow(esc, esc.token_id)}
+                      onClick={() => withdrawEscrow(offer, offer.token_id)}
                       disabled
                     >
                       Withdraw
@@ -94,7 +137,7 @@ export const OffersSentTab = ({
                     <Button
                       btnType="filled"
                       size="small"
-                      onClick={() => withdrawEscrow(esc, esc.token_id)}
+                      onClick={() => withdrawEscrow(offer, offer.token_id)}
                     >
                       Withdraw
                     </Button>

--- a/packages/features/sales-escrows/pages/NFTPage/index.tsx
+++ b/packages/features/sales-escrows/pages/NFTPage/index.tsx
@@ -32,7 +32,7 @@ import { useDialog } from '@connect2ic/react';
 import { getNftCollectionMeta, OrigynClient } from '@origyn-sa/mintjs';
 import { EscrowType } from '../../modals/StartEscrowModal';
 import { Principal } from '@dfinity/principal';
-import { PlaceholderImage } from '@dapp/common-assets';
+import { PlaceholderIcon } from '@dapp/common-assets';
 import { OffersPanel } from './components/OffersPanel';
 
 export const NFTPage = () => {
@@ -178,15 +178,11 @@ export const NFTPage = () => {
                           <img
                             style={{ borderRadius: '18px', width: '100%' }}
                             src={`https://${canisterId}.raw.ic0.app/-/${params.nft_id}/preview`}
-                            onError={(e) => {
-                              e.currentTarget.src = PlaceholderImage;
-                            }}
                           />
                         ) : (
-                          <img
-                            style={{ borderRadius: '18px', width: '100%' }}
-                            src={PlaceholderImage}
-                          />
+                          <Flex align="center" justify="center">
+                            <PlaceholderIcon />
+                          </Flex>
                         )}
                         <Flex flexFlow="column" gap={8}>
                           <p className="secondary_color">{odc?.ownerPrincipalId}</p>
@@ -206,11 +202,7 @@ export const NFTPage = () => {
                                 style={{ width: '32px', height: '32px', borderRadius: '7.5px' }}
                               />
                             ) : (
-                              <img
-                                src={PlaceholderImage}
-                                alt=""
-                                style={{ width: '32px', height: '32px', borderRadius: '7.5px' }}
-                              />
+                              <PlaceholderIcon width={32} height={32} />
                             )}
                             <b>{collectionData?.displayName}</b>
                           </Flex>


### PR DESCRIPTION
• Added SVG in case of there is no PreviewAsset in the NFt. 
• Removed onError from the Images.
• Small fixes to the layout. 
• Checked everywhere for the preview asset not for the onError event like before. 
• improved all the script for the modalEscrows - tabs using nft_batch_origyn() function instead of nft_origyn()

📸 
<img width="1290" alt="Schermata 2023-03-07 alle 15 20 59" src="https://user-images.githubusercontent.com/68469149/223559186-50b817b0-bab4-4c37-8cd6-eb4221925b10.png">

📷 
<img width="1293" alt="Schermata 2023-03-07 alle 15 43 11" src="https://user-images.githubusercontent.com/68469149/223559713-23a618af-dfc5-41e5-9e11-9b22166e851e.png">

📸 
<img width="1351" alt="Schermata 2023-03-07 alle 15 41 27" src="https://user-images.githubusercontent.com/68469149/223559356-d6969134-0292-440c-8491-e45b8fc1edb1.png">
