### PR TITLE
ENG-1500 Fix marketplace search for UnfoldVR

### DIFF
--- a/packages/apps/marketplace/src/pages/Marketplace/index.tsx
+++ b/packages/apps/marketplace/src/pages/Marketplace/index.tsx
@@ -161,7 +161,9 @@ const Marketplace = () => {
     }
 
     if (inputText?.length) {
-      filtered = filtered.filter((odc) => odc?.displayName?.toLowerCase().includes(inputText));
+      filtered = filtered.filter((odc) =>
+        (odc.displayName || odc.id)?.toLowerCase().includes(inputText),
+      );
     }
 
     dispatch({ type: 'filteredOdcs', payload: filtered });

--- a/packages/apps/vault/src/pages/Vault/index.tsx
+++ b/packages/apps/vault/src/pages/Vault/index.tsx
@@ -382,7 +382,9 @@ const VaultPage = () => {
     }
 
     if (inputText?.length) {
-      filtered = filtered.filter((odc) => odc?.displayName?.toLowerCase().includes(inputText));
+      filtered = filtered.filter((odc) =>
+        (odc.displayName || odc.id)?.toLowerCase().includes(inputText),
+      );
     }
 
     dispatch({ type: 'filteredOdcs', payload: filtered });


### PR DESCRIPTION
- UnfoldVR does not use display names for their butterflies, so it defaults to the token id. 
- The search now filters on display name if it exists, then token id.